### PR TITLE
fix(browserify): Can build minified frontend library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,40 @@
 # @railgun-community/lepton
+
 Wallet framework for Railgun
 
 ## Installing
+
 ### With NPM
+
 `npm install @railgun-community/lepton`
 
 ### With Yarn
+
 `yarn add @railgun-community/lepton`
 
 ## Developing
+
 ### Install nodejs
+
 - [Via NVM (recommended)](https://github.com/nvm-sh/nvm)
 - [Via installer](https://nodejs.org)
 
 ### Install modules
+
 `npm install` OR `yarn install`
 
 ### Run mocha tests
+
 `npm test` OR `yarn run test`
 
 ### Compile
-`npm compile` OR `yarn run compile`
+
+`npm run compile` OR `yarn run compile`
+
+### Build minified frontend library
+
+`npm run compile` OR `yarn run build`
 
 ### Clean compile directory
+
 `npm clean` OR `yarn run clean`

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "clean": "rimraf dist && rimraf coverage && rimraf .nyc_output",
     "lint": "eslint src/**/*.ts",
     "test": "npm run lint && nyc mocha --require ts-node/register 'test/**/*.test.ts'",
-    "compile": "npm run clean && tsc"
+    "compile": "npm run clean && tsc",
+    "build": "browserify dist/index.js -p tinyify --s RailgunWallet -o dist/railgun-wallet.min.js"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
     "@types/rimraf": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
+    "browserify": "^17.0.0",
     "chai": "^4.3.4",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -37,6 +39,7 @@
     "mocha": "^9.0.3",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
+    "tinyify": "^3.0.0",
     "ts-node": "^10.1.0",
     "typescript": "^4.3.5"
   },


### PR DESCRIPTION
This PR updates `package.json` with a `build` script. After running `npm run compile` to compile the TS code, you can run `npm run build` to build a minified frontend JS library for use in the browser.