### PR TITLE
Use wasm scalarmult in getSharedSymmetricKeyLegacy

### DIFF
--- a/src/utils/__tests__/keys-utils-legacy.test.ts
+++ b/src/utils/__tests__/keys-utils-legacy.test.ts
@@ -1,0 +1,23 @@
+import { bytesToHex } from '@noble/hashes/utils';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { getSharedSymmetricKeyLegacy } from '../keys-utils-legacy';
+import { hexStringToBytes } from '../bytes';
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+describe('Test keys-utils-legacy', () => {
+  it('getSharedSymmetricKeyLegacy stability', async () => {
+    const privateKeyPairA = hexStringToBytes(
+      '0123456789012345678901234567890123456789012345678901234567891234',
+    );
+    const blindedPublicKeyPairB = hexStringToBytes(
+      '0987654321098765432109876543210987654321098765432109876543210987',
+    );
+    const symmetricKey = await getSharedSymmetricKeyLegacy(privateKeyPairA, blindedPublicKeyPairB);
+    expect(bytesToHex(symmetricKey as Uint8Array)).to.equal(
+      '64df806eadf85aba48fe2a7b4ecc783affcbeb7f63e9c9f6b8eb9422e2322874',
+    );
+  });
+});


### PR DESCRIPTION
## Context

Looking for ways to optimize the performance (and minimize the total duration) of `fullRescanMerkletreesAndWallets` in the Web app.

## Problem

`getSharedSymmetricKeyLegacy` still uses Noble JS for scalar multiplication operations. This is notably slow compared to the wasm alternative.

## Solution

In this PR, we change the internals of the `getSharedSymmetricKeyLegacy` function to use the same `scalarMultiplyWasmFallbackToJavaScript` as `getSharedSymmetricKey` (non-legacy) uses. If I understood correctly, we can't replace `getSharedSymmetricKeyLegacy` with `getSharedSymmetricKey` because the latter uses hashing while the former doesn't, producing different outputs.

## Tests

I added a new test that hard-codes an expected output. The new test is ran on the old implementation (see 1st commit) AND on the new implementation (2nd commit), guaranteeing that the outputs remain the same.

## Performance

I measured the time spent on different phases of `fullRescanMerkletreesAndWallets` and for the "scan balances" phase (where we run several `getSharedSymmetricKeyLegacy` calls) the **before** duration was 16.5s and the **after** duration is 9.7s, **meaning a speed up of approximately 1.7x**.