### PR TITLE
Shim TextEncoder/TextDecoder when in React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "encoding-down": "^7.1.0",
     "ethereum-cryptography": "^2.0.0",
     "ethers": "^6.6.0",
+    "fast-text-encoding": "^1.0.6",
     "levelup": "^5.1.1",
     "msgpack-lite": "^0.1.26"
   },

--- a/src/note/memo.ts
+++ b/src/note/memo.ts
@@ -8,7 +8,14 @@ import { MEMO_SENDER_RANDOM_NULL } from '../models/transaction-constants';
 import { arrayify, ByteLength, hexlify, nToHex } from '../utils/bytes';
 import { aes } from '../utils/encryption';
 import { isDefined } from '../utils/is-defined';
+import { isReactNative } from '../utils/runtime';
 import WalletInfo from '../wallet/wallet-info';
+
+// TextEncoder/TextDecoder (used in this file) needs to shimmed in React Native
+if (isReactNative) {
+  // eslint-disable-next-line global-require
+  require('fast-text-encoding');
+}
 
 // Annotation Data used to be stored as the leading bytes in Memo field.
 export const LEGACY_MEMO_METADATA_BYTE_CHUNKS = 2;

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -2,6 +2,13 @@ import BN from 'bn.js';
 import crypto from 'crypto';
 import { hexToBytes } from 'ethereum-cryptography/utils';
 import { BytesData } from '../models/formatted-types';
+import { isReactNative } from './runtime';
+
+// TextEncoder/TextDecoder (used in this file) needs to shimmed in React Native
+if (isReactNative) {
+  // eslint-disable-next-line global-require
+  require('fast-text-encoding');
+}
 
 export enum ByteLength {
   UINT_8 = 1,

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -1,0 +1,2 @@
+export const isReactNative =
+  typeof navigator !== 'undefined' && navigator.product === 'ReactNative';

--- a/src/utils/scalar-multiply.ts
+++ b/src/utils/scalar-multiply.ts
@@ -2,8 +2,7 @@ import { Point } from '@noble/ed25519';
 import { bytesToHex } from 'ethereum-cryptography/utils';
 import EngineDebug from '../debugger/debugger';
 import { ByteLength, nToBytes } from './bytes';
-
-const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
+import { isReactNative } from './runtime';
 
 interface ScalarMultMod {
   default?: () => Promise<void>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2727,6 +2727,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-text-encoding@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
+  integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
+
 fastfile@0.0.20:
   version "0.0.20"
   resolved "https://registry.yarnpkg.com/fastfile/-/fastfile-0.0.20.tgz#794a143d58cfda2e24c298e5ef619c748c8a1879"


### PR DESCRIPTION
## Problem

When running the engine directly in React Native's JS environment (either JSC or Hermes), we don't have TextEncoder / TextDecoder, so `engine` fails to start.

## Solution

Detect if we are in React Native and shim TextEncoder / TextDecoder using the light ([3kB](https://bundlephobia.com/package/fast-text-encoding)) polyfill `fast-text-encoding`.

Existing users of `engine` in the web or in Node.js (mobile) should be unaffected by this PR.