### PR TITLE
Revert "revert" scalarmult changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@noble/ed25519": "^1.7.1",
     "@noble/hashes": "^1.3.0",
-    "@railgun-community/curve25519-scalarmult-wasm": "0.1.4",
+    "@railgun-community/curve25519-scalarmult-wasm": "0.1.5",
     "@scure/base": "^1.1.1",
     "abstract-leveldown": "^7.2.0",
     "bn.js": "^5.2.1",

--- a/src/utils/__tests__/scalar-multiply.test.ts
+++ b/src/utils/__tests__/scalar-multiply.test.ts
@@ -1,0 +1,20 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { initCurve25519Promise, scalarMultiplyWasmFallbackToJavascript } from '../scalar-multiply';
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+describe('scalarMultiplyWasmFallbackToJavascript', () => {
+  it('Should throw when y coordinate is invalid', async () => {
+    await initCurve25519Promise;
+    const point = new Uint8Array([
+      122, 247, 122, 242, 41, 199, 22, 160, 168, 36, 83, 200, 250, 170, 208, 189, 116, 82, 157, 77,
+      82, 192, 120, 42, 62, 13, 148, 15, 17, 141, 227, 22,
+    ]);
+    const scalar = 10928541092740192740192704n;
+    expect(() => scalarMultiplyWasmFallbackToJavascript(point, scalar)).to.throw(
+      /invalid y coordinate/,
+    );
+  });
+});

--- a/src/utils/scalar-multiply.ts
+++ b/src/utils/scalar-multiply.ts
@@ -2,8 +2,7 @@ import { Point } from '@noble/ed25519';
 import { bytesToHex } from 'ethereum-cryptography/utils';
 import EngineDebug from '../debugger/debugger';
 import { ByteLength, nToBytes } from './bytes';
-
-const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
+import { isReactNative } from './runtime';
 
 interface ScalarMultMod {
   default?: () => Promise<void>;

--- a/src/utils/scalar-multiply.ts
+++ b/src/utils/scalar-multiply.ts
@@ -46,6 +46,10 @@ export const scalarMultiplyWasmFallbackToJavascript = (
     if (!(err instanceof Error)) {
       throw err;
     }
+    if (err.message.includes('invalid y coordinate')) {
+      // Noble/ed25519 would also throw this error, so no need to call Noble
+      throw err;
+    }
     // Fallback to Javascript.
     EngineDebug.log('curve25519-scalarmult-wasm scalarMultiply failed: Fallback to JavaScript');
     EngineDebug.error(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -595,10 +595,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@railgun-community/curve25519-scalarmult-wasm@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@railgun-community/curve25519-scalarmult-wasm/-/curve25519-scalarmult-wasm-0.1.4.tgz#72f84f7d4d15a0deedb679860f07f59953dc21eb"
-  integrity sha512-8F5S6nGAZ/xO3mgFegLtwB9dcEs1Hynn+h775or4dFhWNP+Eh6c8N2vrdlkIfLZ+lFIP798lELBrQC0mplXE7A==
+"@railgun-community/curve25519-scalarmult-wasm@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@railgun-community/curve25519-scalarmult-wasm/-/curve25519-scalarmult-wasm-0.1.5.tgz#edb5e40a8f1fdb7f7e0de1d04e8badabe41cb2a8"
+  integrity sha512-Cur8uM/IdNW3WzUwdPloDG1CF0rpSBDWq2yGXJMZ7IMeBGdc4Jj0h9tnNMFRZ35ZuCVVbZ3yClmqSa4PsbpdGQ==
 
 "@scure/base@^1.1.1", "@scure/base@~1.1.0":
   version "1.1.1"


### PR DESCRIPTION
The problem was actually not in `engine` itself, it was in curve25519-scalarmult-rsjs which is a dependency of mobile apps, not a dependency in `engine`. 

**Additionally**, this PR also adds [this commit](https://github.com/Railgun-Community/engine/pull/42/commits/a81183dd13debe17b727895b9e6cbbe7f7166116) that avoids calling the JS fallback, because the JS fallback would throw the same error. This would end up trashing the logs with a lot of error callstacks.