### PR TITLE
Use our fork of ethers

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "circomlibjs": "hsg88/circomlibjs#ffjavascrip.0.1.0",
     "encoding-down": "^7.1.0",
     "ethereum-cryptography": "^2.0.0",
-    "ethers": "6.6.2",
+    "ethers": "github:Railgun-Community/ethers.js#v6.7.2",
     "fast-text-encoding": "^1.0.6",
     "levelup": "^5.1.1",
     "msgpack-lite": "^0.1.26"

--- a/src/provider/polling-util.ts
+++ b/src/provider/polling-util.ts
@@ -30,7 +30,7 @@ export const createPollingJsonRpcProviderForListeners = async (
     return provider;
   }
 
-  if ('pollingInterval' in provider) {
+  if (provider instanceof JsonRpcProvider) {
     // eslint-disable-next-line no-underscore-dangle
     const { url } = provider._getConnection();
     const { chainId } = await provider.getNetwork();
@@ -44,7 +44,7 @@ export const createPollingJsonRpcProviderForListeners = async (
       throw new Error('Requires 1+ providers in FallbackProvider');
     }
     const firstProvider = provider.providerConfigs[0].provider as JsonRpcProvider;
-    if (!('pollingInterval' in firstProvider)) {
+    if (!(firstProvider instanceof JsonRpcProvider)) {
       throw new Error('First provider in FallbackProvider must be JsonRpcProvider');
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2603,10 +2603,9 @@ ethereumjs-util@^7.0.10, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.5:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.6.2.tgz#0b6131b5fa291fec69b7ae379cb6bb2405c505a7"
-  integrity sha512-vyWfVAj2g7xeZIivOqlbpt7PbS2MzvJkKgsncgn4A/1xZr8Q3BznBmEBRQyPXKCgHmX4PzRQLpnYG7jl/yutMg==
+"ethers@github:Railgun-Community/ethers.js#v6.7.2":
+  version "6.7.2"
+  resolved "https://codeload.github.com/Railgun-Community/ethers.js/tar.gz/0427e0f47e2a9fb0e90885cfa1b5cbd9d829c21d"
   dependencies:
     "@adraffy/ens-normalize" "1.9.2"
     "@noble/hashes" "1.1.2"


### PR DESCRIPTION
The forked Ethers has the following fixes:

- Fix "stalling" in FallbackProvider to be sequential
- Debounces subscriber polling so that getLogs calls are effectively batched with no redundant block ranges
- Fix FallbackProvider's handling of errors so that the first error does not stop attempts on other providers
- Fix FallbackProvider's handling of errors so that an error from one provider during broadcastTransaction does not take priority over another provider's success  

Confirmed that it fixes the following:

> P1. Too many eth_getLogs queries (repeat blocks)

:heavy_check_mark: Yes

> P1. Arbitrum / Arbitrum-Goerli issues too many requests.

:crossed_fingers: This seems to be solved by the provider loading refactor that now cancels the former provider.

> P1. FallbackProvider: stallTimeout is not functional (all queries are issued simultaneously)

:heavy_check_mark: Yes

> P2. FallbackProvider call: Promise.race - first failure throws error, does not fallback

:heavy_check_mark: Yes

> P2. FallbackProvider Transaction submission - Promise.all (?) hits error after first success: "already seen"

:crossed_fingers: In theory, yes, but I haven't reproduced (neither before nor after the fix). I can't broadcast a transaction because **I can't connect to relayers**, and I can't send self-proved transactions because my test wallet has zero ETH to pay fees.

> P3. On app resume, 100k+ block query sent for eth_getLogs . Hits rate limit threshold. (Maximum block numbers in query should be configurable).

:crossed_fingers: This one is hard to reproduce, but we can assume it's fixed by either our new fork or the provider loading refactor, or a combination of both.