### PR TITLE
ci: use hardhat server in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,19 +10,35 @@ on:
 
 jobs:
   integration-tests:
-    name: 🧪 Test
+    name: 🧪 Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
-          cache: 'yarn'
-      - name: Install yarn
+      - name: Checkout engine repo
+        uses: actions/checkout@v3
+        with:
+          path: engine
+      - name: Checkout contract repo
+        uses: actions/checkout@v3
+        with:
+          repository: Railgun-Privacy/contract
+          token: ${{ secrets.RAILGUN_PRIVACY_ACCESS_TOKEN }}
+          path: contract
+      - name: Yarn in engine
         uses: borales/actions-yarn@v4
         with:
           cmd: install
-      - name: Yarn test up to 3 times
-        shell: bash
-        run: # Try yarn test 3 times before failing
-          r=3;while ! yarn test ; do ((--r))||exit;sleep 1;done
+          dir: 'engine'
+      - name: Yarn in contract
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: install
+          dir: 'contract'
+      - name: Run contract hardhat and engine tests
+        uses: BerniWittmann/background-server-action@v1
+        with:
+          command: cd engine && yarn test-hardhat
+          start: cd contract && npx hardhat node >/dev/null, cd contract && sleep 5 && npx hardhat deploy:test --network localhost >/dev/null
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   unit-tests:
-    name: 🧪 Test
+    name: 🧪 Unit Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Runs hardhat as a server, so we can run `npm run test-hardhat` in the foreground.

The integration tests fail, but they also fail on my local computer, so I suspect we have a real issue that needs fixing. It looks like this:

```
Error: Event topic not recognized
    at Proxy.<anonymous> (/home/runner/work/engine/engine/engine/src/contracts/railgun-smart-wallet/railgun-smart-wallet.ts:342:17)
    at /home/runner/work/engine/engine/engine/node_modules/ethers/src.ts/contract/contract.ts:603:22
    at Array.filter (<anonymous>)
    at _emit (/home/runner/work/engine/engine/engine/node_modules/ethers/src.ts/contract/contract.ts:597:35)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```