### PR TITLE
Avoid infinite recursion in syncRailgunTransactionsPoller

### DIFF
--- a/src/railgun-engine.ts
+++ b/src/railgun-engine.ts
@@ -645,12 +645,14 @@ class RailgunEngine extends EventEmitter {
     chain: Chain,
     refreshDelayMsec: number,
   ) {
-    await this.syncRailgunTransactionsForTXIDVersion(txidVersion, chain, 'poller');
-
-    await delay(refreshDelayMsec);
-
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.syncRailgunTransactionsPoller(txidVersion, chain, refreshDelayMsec);
+    const poll = async () => {
+      await this.syncRailgunTransactionsForTXIDVersion(txidVersion, chain, 'poller');
+      await delay(refreshDelayMsec);
+    }
+    while (true) {
+      // eslint-disable-next-line no-await-in-loop
+      await poll();
+    }
   }
 
   /**


### PR DESCRIPTION
This isn't a fix for anything specific, it's just a precaution I found while reading the code.

This poller stays up forever, and runs every 3min. Implemented with recursion, there is a chance that this can cause crashes for users keeping the application open for long periods of time.