### PR TITLE
Make encryption functions lighter on RAM

### DIFF
--- a/src/note/memo.ts
+++ b/src/note/memo.ts
@@ -5,7 +5,7 @@ import {
   OutputType,
 } from '../models/formatted-types';
 import { MEMO_SENDER_RANDOM_NULL } from '../models/transaction-constants';
-import { arrayify, ByteLength, hexlify, nToHex } from '../utils/bytes';
+import { ByteLength, fastHexToBytes, hexlify, nToHex } from '../utils/bytes';
 import { AES } from '../utils/encryption';
 import { isDefined } from '../utils/is-defined';
 import { isReactNative } from '../utils/runtime';
@@ -115,6 +115,6 @@ export class Memo {
     if (!encoded.length) {
       return undefined;
     }
-    return new TextDecoder().decode(Buffer.from(arrayify(encoded)));
+    return new TextDecoder().decode(fastHexToBytes(encoded));
   }
 }

--- a/src/utils/__tests__/ciphertext.test.ts
+++ b/src/utils/__tests__/ciphertext.test.ts
@@ -1,6 +1,5 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { BytesData } from '../../models/formatted-types';
 import { randomHex } from '../bytes';
 import {
   ciphertextToEncryptedJSONData,
@@ -14,7 +13,7 @@ const { expect } = chai;
 
 describe('ciphertext', () => {
   it('Should translate ciphertext to encrypted random and back', () => {
-    const plaintext: BytesData[] = [randomHex(16)];
+    const plaintext: string[] = [randomHex(16)];
     const key = randomHex(32);
     const ciphertext = AES.encryptGCM(plaintext, key);
 
@@ -25,7 +24,7 @@ describe('ciphertext', () => {
   });
 
   it('Should translate ciphertext to encrypted data and back', () => {
-    const plaintext: BytesData[] = [];
+    const plaintext: string[] = [];
     for (let i = 0; i < 40; i += 1) plaintext.push(randomHex(32));
     const key = randomHex(32);
     const ciphertext = AES.encryptGCM(plaintext, key);

--- a/src/utils/__tests__/encryption.test.ts
+++ b/src/utils/__tests__/encryption.test.ts
@@ -1,6 +1,5 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { BytesData } from '../../models/formatted-types';
 import { ByteLength, nToHex, randomHex } from '../bytes';
 import { AES } from '../encryption';
 
@@ -9,7 +8,7 @@ const { expect } = chai;
 
 describe('encryption', () => {
   it('Should test the correctness of encrypt/decrypt with AES-256-GCM', () => {
-    const plaintext: BytesData[] = [];
+    const plaintext: string[] = [];
     for (let i = 0; i < 8; i += 1) plaintext.push(randomHex(32));
     const key = randomHex(32);
     const ciphertext = AES.encryptGCM(plaintext, key);
@@ -28,7 +27,7 @@ describe('encryption', () => {
   });
 
   it('Should reject invalid tag', () => {
-    const plaintext: BytesData[] = [];
+    const plaintext: string[] = [];
     for (let i = 0; i < 8; i += 1) plaintext.push(randomHex(32));
     const key = randomHex(32);
     const ciphertext = AES.encryptGCM(plaintext, key);

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -231,9 +231,8 @@ function assertBytesWithinRange(string: string) {
  * @param data - bytes data to convert
  * @param encoding - string encoding to use
  */
-function toUTF8String(data: BytesData): string {
-  // TODO: Remove reliance on Buffer
-  const string = new TextDecoder().decode(Buffer.from(arrayify(data)));
+function toUTF8String(data: string): string {
+  const string = new TextDecoder().decode(fastHexToBytes(data));
   assertBytesWithinRange(string);
   return string;
 }

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -371,6 +371,41 @@ export function hexStringToBytes(hex: string): Uint8Array {
 }
 
 /**
+ * Convert hex string to Uint8Array. Does not handle 0x prefixes, and assumes
+ * your string has an even number of characters.
+ * @param {string} str
+ * @returns {Uint8Array}
+ */
+export function fastHexToBytes(str: string) {
+  const bytes = new Uint8Array(str.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    const c1 = str.charCodeAt(i * 2);
+    const c2 = str.charCodeAt(i * 2 + 1);
+    const n1 = c1 - (c1 < 58 ? 48 : 87);
+    const n2 = c2 - (c2 < 58 ? 48 : 87);
+    bytes[i] = n1 * 16 + n2;
+  }
+  return bytes;
+}
+
+/**
+ * Convert Uint8Array to hex string. Does not output 0x prefixes.
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+export function fastBytesToHex(bytes: Uint8Array) {
+  let hex = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    const n = bytes[i];
+    const c1 = (n / 16) | 0;
+    const c2 = n % 16;
+    hex += String.fromCharCode(c1 + (c1 < 10 ? 48 : 87));
+    hex += String.fromCharCode(c2 + (c2 < 10 ? 48 : 87));
+  }
+  return hex;
+}
+
+/**
  * Generates random bytes
  * @param length - number of bytes to generate
  * @returns random bytes hex string

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -376,7 +376,7 @@ export function hexStringToBytes(hex: string): Uint8Array {
  * @param {string} str
  * @returns {Uint8Array}
  */
-export function fastHexToBytes(str: string) {
+export function fastHexToBytes(str: string): Uint8Array {
   const bytes = new Uint8Array(str.length / 2);
   for (let i = 0; i < bytes.length; i += 1) {
     const c1 = str.charCodeAt(i * 2);
@@ -393,16 +393,16 @@ export function fastHexToBytes(str: string) {
  * @param {Uint8Array} bytes
  * @returns {string}
  */
-export function fastBytesToHex(bytes: Uint8Array) {
-  let hex = '';
+export function fastBytesToHex(bytes: Uint8Array): string {
+  const hex = new Array(bytes.length * 2);
   for (let i = 0; i < bytes.length; i += 1) {
     const n = bytes[i];
     const c1 = (n / 16) | 0;
     const c2 = n % 16;
-    hex += String.fromCharCode(c1 + (c1 < 10 ? 48 : 87));
-    hex += String.fromCharCode(c2 + (c2 < 10 ? 48 : 87));
+    hex[2 * i] = String.fromCharCode(c1 + (c1 < 10 ? 48 : 87));
+    hex[2 * i + 1] = String.fromCharCode(c2 + (c2 < 10 ? 48 : 87));
   }
-  return hex;
+  return hex.join('');
 }
 
 /**

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -1,4 +1,11 @@
-import { arrayify, ByteLength, formatToByteLength, padToLength, randomHex, trim } from './bytes';
+import {
+  arrayify,
+  ByteLength,
+  fastBytesToHex,
+  fastHexToBytes,
+  formatToByteLength,
+  randomHex,
+} from './bytes';
 import { BytesData, Ciphertext, CTRCiphertext } from '../models/formatted-types';
 import { isNodejs } from './runtime';
 
@@ -21,10 +28,9 @@ export class AES {
    * @param key - key to encrypt with
    * @returns ciphertext bundle
    */
-  static encryptGCM(plaintext: BytesData[], key: BytesData): Ciphertext {
+  static encryptGCM(plaintext: string[], key: string | Uint8Array): Ciphertext {
     // If types are strings, convert to bytes array
-    const plaintextFormatted = plaintext.map((block) => new Uint8Array(arrayify(block)));
-    const keyFormatted = new Uint8Array(arrayify(key));
+    const keyFormatted = typeof key === 'string' ? fastHexToBytes(key) : key;
     if (keyFormatted.byteLength !== 32) {
       throw new Error(
         `Invalid key length. Expected 32 bytes. Received ${keyFormatted.byteLength} bytes.`,
@@ -32,7 +38,7 @@ export class AES {
     }
 
     const iv = AES.getRandomIV();
-    const ivFormatted = new Uint8Array(arrayify(iv));
+    const ivFormatted = fastHexToBytes(iv);
 
     // Initialize cipher
     const cipher = createCipheriv('aes-256-gcm', keyFormatted, ivFormatted, {
@@ -40,9 +46,10 @@ export class AES {
     });
 
     // Loop through data blocks and encrypt
-    const data = plaintextFormatted
-      .map((block) => cipher.update(block))
-      .map((block) => block.toString('hex'));
+    const data = new Array<string>(plaintext.length);
+    for (let i = 0; i < plaintext.length; i += 1) {
+      data[i] = fastBytesToHex(cipher.update(fastHexToBytes(plaintext[i])));
+    }
     cipher.final();
 
     const tag = cipher.getAuthTag();
@@ -63,13 +70,27 @@ export class AES {
    * @param key - key to decrypt with
    * @returns - plaintext
    */
-  static decryptGCM(ciphertext: Ciphertext, key: BytesData): BytesData[] {
+  static decryptGCM(ciphertext: Ciphertext, key: string | Uint8Array): BytesData[] {
     try {
-      // If types are strings, convert to bytes array
-      const ciphertextFormatted = ciphertext.data.map((block) => new Uint8Array(arrayify(block)));
-      const keyFormatted = new Uint8Array(arrayify(padToLength(key, 32)));
-      const ivFormatted = new Uint8Array(arrayify(trim(ciphertext.iv, 16)));
-      const tagFormatted = new Uint8Array(arrayify(trim(ciphertext.tag, 16)));
+      // Ensure that inputs are Uint8Arrays of the correct length
+      const keyFormatted = typeof key === 'string' ? fastHexToBytes(key) : key;
+      if (keyFormatted.byteLength !== 32) {
+        throw new Error(
+          `Invalid key length. Expected 32 bytes. Received ${keyFormatted.byteLength} bytes.`,
+        );
+      }
+      const ivFormatted = fastHexToBytes(ciphertext.iv);
+      const tagFormatted = fastHexToBytes(ciphertext.tag);
+      if (ivFormatted.byteLength !== 16) {
+        throw new Error(
+          `Invalid iv length. Expected 16 bytes. Received ${ivFormatted.byteLength} bytes.`,
+        );
+      }
+      if (tagFormatted.byteLength !== 16) {
+        throw new Error(
+          `Invalid tag length. Expected 16 bytes. Received ${tagFormatted.byteLength} bytes.`,
+        );
+      }
 
       // Initialize decipher
       const decipher = createDecipheriv('aes-256-gcm', keyFormatted, ivFormatted, {
@@ -80,9 +101,10 @@ export class AES {
       decipher.setAuthTag(tagFormatted);
 
       // Loop through ciphertext and decrypt then return
-      const data = ciphertextFormatted
-        .map((block) => decipher.update(block))
-        .map((block) => block.toString('hex'));
+      const data = new Array<string>(ciphertext.data.length);
+      for (let i = 0; i < ciphertext.data.length; i += 1) {
+        data[i] = fastBytesToHex(decipher.update(fastHexToBytes(ciphertext.data[i])));
+      }
       decipher.final();
       return data;
     } catch (err) {
@@ -99,10 +121,9 @@ export class AES {
    * @param key - key to encrypt with
    * @returns ciphertext bundle
    */
-  static encryptCTR(plaintext: string[], key: BytesData): CTRCiphertext {
+  static encryptCTR(plaintext: string[], key: string | Uint8Array): CTRCiphertext {
     // If types are strings, convert to bytes array
-    const plaintextFormatted = plaintext.map((block) => new Uint8Array(arrayify(block)));
-    const keyFormatted = new Uint8Array(arrayify(key));
+    const keyFormatted = typeof key === 'string' ? fastHexToBytes(key) : key;
     if (keyFormatted.byteLength !== 32) {
       throw new Error(
         `Invalid key length. Expected 32 bytes. Received ${keyFormatted.byteLength} bytes.`,
@@ -110,15 +131,16 @@ export class AES {
     }
 
     const iv = AES.getRandomIV();
-    const ivFormatted = new Uint8Array(arrayify(iv));
+    const ivFormatted = fastHexToBytes(iv);
 
     // Initialize cipher
     const cipher = createCipheriv('aes-256-ctr', keyFormatted, ivFormatted);
 
     // Loop through data blocks and encrypt
-    const data = plaintextFormatted
-      .map((block) => cipher.update(block))
-      .map((block) => block.toString('hex'));
+    const data = new Array<string>(plaintext.length);
+    for (let i = 0; i < plaintext.length; i += 1) {
+      data[i] = fastBytesToHex(cipher.update(fastHexToBytes(plaintext[i])));
+    }
     cipher.final();
 
     // Return encrypted data bundle
@@ -135,19 +157,30 @@ export class AES {
    * @param key - key to decrypt with
    * @returns - plaintext
    */
-  static decryptCTR(ciphertext: CTRCiphertext, key: BytesData): string[] {
+  static decryptCTR(ciphertext: CTRCiphertext, key: string | Uint8Array): string[] {
     // If types are strings, convert to bytes array
-    const ciphertextFormatted = ciphertext.data.map((block) => new Uint8Array(arrayify(block)));
-    const keyFormatted = new Uint8Array(arrayify(padToLength(key, 32)));
-    const ivFormatted = new Uint8Array(arrayify(trim(ciphertext.iv, 16)));
+    const keyFormatted = typeof key === 'string' ? fastHexToBytes(key) : key;
+    if (keyFormatted.byteLength !== 32) {
+      throw new Error(
+        `Invalid key length. Expected 32 bytes. Received ${keyFormatted.byteLength} bytes.`,
+      );
+    }
+
+    const ivFormatted = fastHexToBytes(ciphertext.iv);
+    if (ivFormatted.byteLength !== 16) {
+      throw new Error(
+        `Invalid iv length. Expected 16 bytes. Received ${ivFormatted.byteLength} bytes.`,
+      );
+    }
 
     // Initialize decipher
     const decipher = createDecipheriv('aes-256-ctr', keyFormatted, ivFormatted);
 
     // Loop through ciphertext and decrypt then return
-    const data = ciphertextFormatted
-      .map((block) => decipher.update(block))
-      .map((block) => block.toString('hex'));
+    const data = new Array<string>(ciphertext.data.length);
+    for (let i = 0; i < ciphertext.data.length; i += 1) {
+      data[i] = fastBytesToHex(decipher.update(fastHexToBytes(ciphertext.data[i])));
+    }
     decipher.final();
     return data;
   }

--- a/src/wallet/abstract-wallet.ts
+++ b/src/wallet/abstract-wallet.ts
@@ -45,6 +45,7 @@ import {
   arrayify,
   ByteLength,
   combine,
+  fastHexToBytes,
   formatToByteLength,
   fromUTF8String,
   hexlify,
@@ -2852,7 +2853,7 @@ abstract class AbstractWallet extends EventEmitter {
     encryptionKey: string,
   ): Promise<WalletData | ViewOnlyWalletData> {
     return msgpack.decode(
-      arrayify(await db.getEncrypted(AbstractWallet.dbPath(id), encryptionKey)),
+      fastHexToBytes(await db.getEncrypted(AbstractWallet.dbPath(id), encryptionKey)),
     );
   }
 
@@ -2881,7 +2882,7 @@ abstract class AbstractWallet extends EventEmitter {
     id: string,
   ): Promise<WalletData | ViewOnlyWalletData> {
     return msgpack.decode(
-      arrayify(await db.getEncrypted([fromUTF8String('wallet'), id], encryptionKey)),
+      fastHexToBytes(await db.getEncrypted([fromUTF8String('wallet'), id], encryptionKey)),
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,11 +870,6 @@
     "@types/level-errors" "*"
     "@types/node" "*"
 
-"@types/lodash@^4.14.199":
-  version "4.14.199"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.199.tgz#c3edb5650149d847a277a8961a7ad360c474e9bf"
-  integrity sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==
-
 "@types/memdown@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/memdown/-/memdown-3.0.1.tgz#32aeb5609d89d55f11f69d06bb76ffb24a6e031a"


### PR DESCRIPTION
## Summary

Even though the ciphertext.data was just 22MB in total (Array with 350 thousand strings), the intermediate arrays we created in the process (arrayify, `.map`, etc) made memory consumption go up some 500MB.

## Before

<img width="662" alt="Screenshot 2023-10-24 at 10 41 16" src="https://github.com/Railgun-Community/engine/assets/90512/7a203b6c-ac84-421c-a728-a94acc7d6b62">


## After

<img width="724" alt="Screenshot 2023-10-24 at 14 35 02" src="https://github.com/Railgun-Community/engine/assets/90512/6041651d-8019-4145-bba7-025d0fb11a76">

