### PR TITLE
Sanitize TransactNote memo before decrypt

### DIFF
--- a/src/note/transact-note.ts
+++ b/src/note/transact-note.ts
@@ -22,6 +22,7 @@ import {
   nToBytes,
   nToHex,
   randomHex,
+  strip0x,
 } from '../utils/bytes';
 import { ciphertextToEncryptedRandomData, encryptedDataToCiphertext } from '../utils/ciphertext';
 import { AES } from '../utils/encryption';
@@ -317,7 +318,7 @@ export class TransactNote {
     tokenDataGetter: TokenDataGetter,
     blockNumber: Optional<number>,
   ): Promise<TransactNote> {
-    const ciphertextDataWithMemoText = [...noteCiphertext.data, memo];
+    const ciphertextDataWithMemoText = [...noteCiphertext.data, strip0x(memo)];
     const fullCiphertext: Ciphertext = {
       ...noteCiphertext,
       data: ciphertextDataWithMemoText,

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -86,10 +86,8 @@ export class AES {
       decipher.final();
       return data;
     } catch (err) {
-      if (!(err instanceof Error)) {
-        throw err;
-      }
-      throw new Error('Unable to decrypt ciphertext.');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      throw new Error('Unable to decrypt ciphertext.', { cause: err });
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "files": true
   },
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,


### PR DESCRIPTION
In some **memo**, there was a rogue **empty** hex, but represented as the string `"0x"`. The new encryption/decryption implementation makes stricter assumptions on the inputs nowadays, it wants the empty string `""`, so we have to sanitize the inputs before passing them to `decryptGCM()`.

✅ Passes `engine` unit tests locally.
✅ Passes `wallet` unit tests locally.

**Bonus**: to better detect what kind of failed decryption happened, I'm now including the suberror using Error.cause. This in turn requires updating tsconfig to use ES2022, which is supported in Node.js >=16 and modern browsers.