### PR TITLE
Make encryption functions lighter on RAM

### DIFF
--- a/src/contracts/relay-adapt/__tests__/relay-adapt.test.ts
+++ b/src/contracts/relay-adapt/__tests__/relay-adapt.test.ts
@@ -470,7 +470,7 @@ describe('relay-adapt', function test() {
     const crossContractCalls: ContractTransaction[] = [];
 
     // 4. Create shield inputs.
-    const shieldRandom = '0x10203040506070809000102030405060';
+    const shieldRandom = '10203040506070809000102030405060';
     const relayShieldInputs = await RelayAdaptHelper.generateRelayShieldRequests(
       shieldRandom,
       [],
@@ -546,14 +546,14 @@ describe('relay-adapt', function test() {
     );
 
     // 9: Send relay transaction.
-    const txResponse = await sendTransactionWithLatestNonce(ethersWallet, relayTransaction);
+    const txResponse = sendTransactionWithLatestNonce(ethersWallet, relayTransaction);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_t, _u, txReceipt] = await Promise.all([
       awaitRailgunSmartWalletTransact(railgunSmartWalletContract),
       awaitRailgunSmartWalletUnshield(railgunSmartWalletContract),
-      txResponse.wait(),
-      promiseTimeout(awaitScan(wallet, chain), 10000, 'Timed out waiting for scan'),
+      txResponse.then(x => x.wait()),
+      promiseTimeout(awaitScan(wallet, chain), 30000, 'Timed out waiting for scan'),
     ]);
     if (txReceipt == null) {
       throw new Error('No transaction receipt for relay transaction');
@@ -695,7 +695,7 @@ describe('relay-adapt', function test() {
     ];
 
     // 4. Create shield inputs.
-    const shieldRandom = '0x10203040506070809000102030405060';
+    const shieldRandom = '10203040506070809000102030405060';
     const shieldERC20Addresses: RelayAdaptShieldERC20Recipient[] = [
       { tokenAddress: WETH_TOKEN_ADDRESS, recipientAddress: wallet.getAddress() },
     ];

--- a/src/note/memo.ts
+++ b/src/note/memo.ts
@@ -5,7 +5,7 @@ import {
   OutputType,
 } from '../models/formatted-types';
 import { MEMO_SENDER_RANDOM_NULL } from '../models/transaction-constants';
-import { arrayify, ByteLength, hexlify, nToHex } from '../utils/bytes';
+import { ByteLength, fastHexToBytes, hexlify, nToHex } from '../utils/bytes';
 import { AES } from '../utils/encryption';
 import { isDefined } from '../utils/is-defined';
 import { isReactNative } from '../utils/runtime';
@@ -115,6 +115,6 @@ export class Memo {
     if (!encoded.length) {
       return undefined;
     }
-    return new TextDecoder().decode(Buffer.from(arrayify(encoded)));
+    return new TextDecoder().decode(fastHexToBytes(encoded));
   }
 }

--- a/src/note/transact-note.ts
+++ b/src/note/transact-note.ts
@@ -22,6 +22,7 @@ import {
   nToBytes,
   nToHex,
   randomHex,
+  strip0x,
 } from '../utils/bytes';
 import { ciphertextToEncryptedRandomData, encryptedDataToCiphertext } from '../utils/ciphertext';
 import { AES } from '../utils/encryption';
@@ -317,7 +318,7 @@ export class TransactNote {
     tokenDataGetter: TokenDataGetter,
     blockNumber: Optional<number>,
   ): Promise<TransactNote> {
-    const ciphertextDataWithMemoText = [...noteCiphertext.data, memo];
+    const ciphertextDataWithMemoText = [...noteCiphertext.data, strip0x(memo)];
     const fullCiphertext: Ciphertext = {
       ...noteCiphertext,
       data: ciphertextDataWithMemoText,

--- a/src/test/helper.test.ts
+++ b/src/test/helper.test.ts
@@ -137,7 +137,7 @@ export const awaitRailgunSmartWalletEvent = async (
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       railgunSmartWallet.contractForListeners.once(event, () => resolve());
     }),
-    15000,
+    30000,
     `Timed out waiting for RailgunSmartWallet event: ${event.fragment.name}`,
   );
 };

--- a/src/utils/__tests__/ciphertext.test.ts
+++ b/src/utils/__tests__/ciphertext.test.ts
@@ -1,6 +1,5 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { BytesData } from '../../models/formatted-types';
 import { randomHex } from '../bytes';
 import {
   ciphertextToEncryptedJSONData,
@@ -14,7 +13,7 @@ const { expect } = chai;
 
 describe('ciphertext', () => {
   it('Should translate ciphertext to encrypted random and back', () => {
-    const plaintext: BytesData[] = [randomHex(16)];
+    const plaintext: string[] = [randomHex(16)];
     const key = randomHex(32);
     const ciphertext = AES.encryptGCM(plaintext, key);
 
@@ -25,7 +24,7 @@ describe('ciphertext', () => {
   });
 
   it('Should translate ciphertext to encrypted data and back', () => {
-    const plaintext: BytesData[] = [];
+    const plaintext: string[] = [];
     for (let i = 0; i < 40; i += 1) plaintext.push(randomHex(32));
     const key = randomHex(32);
     const ciphertext = AES.encryptGCM(plaintext, key);

--- a/src/utils/__tests__/encryption.test.ts
+++ b/src/utils/__tests__/encryption.test.ts
@@ -1,6 +1,5 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { BytesData } from '../../models/formatted-types';
 import { ByteLength, nToHex, randomHex } from '../bytes';
 import { AES } from '../encryption';
 
@@ -9,7 +8,7 @@ const { expect } = chai;
 
 describe('encryption', () => {
   it('Should test the correctness of encrypt/decrypt with AES-256-GCM', () => {
-    const plaintext: BytesData[] = [];
+    const plaintext: string[] = [];
     for (let i = 0; i < 8; i += 1) plaintext.push(randomHex(32));
     const key = randomHex(32);
     const ciphertext = AES.encryptGCM(plaintext, key);
@@ -28,7 +27,7 @@ describe('encryption', () => {
   });
 
   it('Should reject invalid tag', () => {
-    const plaintext: BytesData[] = [];
+    const plaintext: string[] = [];
     for (let i = 0; i < 8; i += 1) plaintext.push(randomHex(32));
     const key = randomHex(32);
     const ciphertext = AES.encryptGCM(plaintext, key);

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -231,9 +231,8 @@ function assertBytesWithinRange(string: string) {
  * @param data - bytes data to convert
  * @param encoding - string encoding to use
  */
-function toUTF8String(data: BytesData): string {
-  // TODO: Remove reliance on Buffer
-  const string = new TextDecoder().decode(Buffer.from(arrayify(data)));
+function toUTF8String(data: string): string {
+  const string = new TextDecoder().decode(fastHexToBytes(data));
   assertBytesWithinRange(string);
   return string;
 }
@@ -368,6 +367,41 @@ export function bytesToN(bytes: Uint8Array): bigint {
  */
 export function hexStringToBytes(hex: string): Uint8Array {
   return hexToBytes(strip0x(hex));
+}
+
+/**
+ * Convert hex string to Uint8Array. Does not handle 0x prefixes, and assumes
+ * your string has an even number of characters.
+ * @param {string} str
+ * @returns {Uint8Array}
+ */
+export function fastHexToBytes(str: string): Uint8Array {
+  const bytes = new Uint8Array(str.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    const c1 = str.charCodeAt(i * 2);
+    const c2 = str.charCodeAt(i * 2 + 1);
+    const n1 = c1 - (c1 < 58 ? 48 : 87);
+    const n2 = c2 - (c2 < 58 ? 48 : 87);
+    bytes[i] = n1 * 16 + n2;
+  }
+  return bytes;
+}
+
+/**
+ * Convert Uint8Array to hex string. Does not output 0x prefixes.
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+export function fastBytesToHex(bytes: Uint8Array): string {
+  const hex = new Array(bytes.length * 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    const n = bytes[i];
+    const c1 = (n / 16) | 0;
+    const c2 = n % 16;
+    hex[2 * i] = String.fromCharCode(c1 + (c1 < 10 ? 48 : 87));
+    hex[2 * i + 1] = String.fromCharCode(c2 + (c2 < 10 ? 48 : 87));
+  }
+  return hex.join('');
 }
 
 /**

--- a/src/wallet/abstract-wallet.ts
+++ b/src/wallet/abstract-wallet.ts
@@ -45,6 +45,7 @@ import {
   arrayify,
   ByteLength,
   combine,
+  fastHexToBytes,
   formatToByteLength,
   fromUTF8String,
   hexlify,
@@ -2856,7 +2857,7 @@ abstract class AbstractWallet extends EventEmitter {
     encryptionKey: string,
   ): Promise<WalletData | ViewOnlyWalletData> {
     return msgpack.decode(
-      arrayify(await db.getEncrypted(AbstractWallet.dbPath(id), encryptionKey)),
+      fastHexToBytes(await db.getEncrypted(AbstractWallet.dbPath(id), encryptionKey)),
     );
   }
 
@@ -2885,7 +2886,7 @@ abstract class AbstractWallet extends EventEmitter {
     id: string,
   ): Promise<WalletData | ViewOnlyWalletData> {
     return msgpack.decode(
-      arrayify(await db.getEncrypted([fromUTF8String('wallet'), id], encryptionKey)),
+      fastHexToBytes(await db.getEncrypted([fromUTF8String('wallet'), id], encryptionKey)),
     );
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "files": true
   },
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,


### PR DESCRIPTION
Second attempt at https://github.com/Railgun-Community/engine/pull/58

## Performance on web

### Web Worker heap max 97MB 👍 
<img width="1280" alt="Screenshot 2023-11-08 at 15 57 39" src="https://github.com/Railgun-Community/engine/assets/90512/fa49fe4e-0b84-43a7-818e-7d61db35d752">

### Main thread heap max 189MB 👍 
<img width="1280" alt="Screenshot 2023-11-08 at 15 57 54" src="https://github.com/Railgun-Community/engine/assets/90512/51cb23ae-5bbb-4d88-a0f5-af255ed60b92">

## Tested locally

- ✅ Engine unit tests
- ✅ Engine Hardhat tests
- ✅ Wallet unit tests
- ✅ Railway web: app starts up, scans balance, can send a private tx
- ✅ Railway mobile (iOS): app starts up, scans balance, can send a private tx

