### PR TITLE
Improve getTreeAndPositionBeforeBlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "snarkjs": "^0.7.0",
     "ts-node": "^10.9.1",
     "typechain": "^8.2.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.4.2"
   },
   "react-native": {
     "@railgun-community/curve25519-scalarmult-wasm": false,

--- a/src/merkletree/merkletree.ts
+++ b/src/merkletree/merkletree.ts
@@ -356,12 +356,12 @@ export abstract class Merkletree<T extends MerkletreeLeaf> {
    * @returns tree length
    */
   async getTreeLength(treeIndex: number): Promise<number> {
-    if (this.treeLengths[treeIndex] != null) {
+    if (isDefined(this.treeLengths[treeIndex])) {
       return this.treeLengths[treeIndex];
     }
 
     const storedMetadata = await this.getMerkletreesMetadata();
-    if (isDefined(storedMetadata) && isDefined(storedMetadata.trees[treeIndex])) {
+    if (isDefined(storedMetadata?.trees[treeIndex])) {
       this.treeLengths[treeIndex] = storedMetadata.trees[treeIndex].scannedHeight;
       return this.treeLengths[treeIndex];
     }

--- a/src/wallet/abstract-wallet.ts
+++ b/src/wallet/abstract-wallet.ts
@@ -3122,7 +3122,7 @@ abstract class AbstractWallet extends EventEmitter {
     latestTree: number,
     creationBlockNumber: number,
   ): Promise<Optional<{ tree: number; position: number }>> {
-    if (creationBlockNumber == null) {
+    if (!isDefined(creationBlockNumber)) {
       return undefined;
     }
 
@@ -3153,9 +3153,9 @@ abstract class AbstractWallet extends EventEmitter {
         if (!isDefined(earliestCommitmentIndex)) {
           // Search through leaves (descending) for first blockNumber before creation.
           // Do this linearly, as we don't expect many commitments in a single block.
-          for (let index = leaves.length - 1; index >= batchStart; index -= 1) {
+          for (let index = batchEnd - 1; index >= batchStart; index -= 1) {
             const commitment = leaves[index];
-            if (commitment != null && commitment.blockNumber != null) {
+            if (isDefined(commitment?.blockNumber)) {
               if (commitment.blockNumber <= creationBlockNumber) {
                 earliestCommitmentIndex = index;
                 creationBlockIndexBlockNumber = commitment.blockNumber;
@@ -3165,7 +3165,7 @@ abstract class AbstractWallet extends EventEmitter {
           }
         }
 
-        if (earliestCommitmentIndex != null) {
+        if (isDefined(earliestCommitmentIndex)) {
           // Check if any commitments earlier in the leaves array are also equal to creationBlockIndex's blockNumber.
           // This can happen if there are multiple commitments in the same block.
           // If so, return the earliest one.
@@ -3176,7 +3176,7 @@ abstract class AbstractWallet extends EventEmitter {
             }
 
             const commitment = leaves[index];
-            if (commitment != null && commitment.blockNumber != null) {
+            if (isDefined(commitment?.blockNumber)) {
               if (commitment.blockNumber === creationBlockIndexBlockNumber) {
                 earliestCommitmentIndex = index;
               } else if (commitment.blockNumber < creationBlockIndexBlockNumber) {
@@ -3186,7 +3186,7 @@ abstract class AbstractWallet extends EventEmitter {
             }
           }
 
-          if (earliestCommitmentIndex > batchStart) {
+          if (earliestCommitmentIndex >= batchStart) {
             return { tree, position: earliestCommitmentIndex };
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5636,10 +5636,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Context

Trying to make integration tests (V2) pass.

## Problem

In one of the hardhat integration tests, these lines fail:

```js
const walletDetails = await wallet.getWalletDetails(txidVersion, chain);
expect(walletDetails.creationTree).to.equal(0);
```

With the following:

```
  1) railgun-engine
       [HH] With a creation block number provided, should show balance after shield and rescan:
     AssertionError: expected undefined to equal +0
      at Context.run (src/__tests__/railgun-engine.test.ts:500:43)
```

## Solution

Digging into `getWalletDetails`, I realized that `AbstractWallet.decryptBalances()` calls `AbstractWallet.getTreeAndPositionBeforeBlock()` 

https://github.com/Railgun-Community/engine/blob/1dbcc3ce2a4b1c2b4a017da771ea01c71c7daf89/src/wallet/abstract-wallet.ts#L2895

in order to calculate `walletDetails.creationTree`

https://github.com/Railgun-Community/engine/blob/1dbcc3ce2a4b1c2b4a017da771ea01c71c7daf89/src/wallet/abstract-wallet.ts#L2901

But in the context of tests where the merkletree is pretty small and we end up with zeroes as the outputs, it seems `getTreeAndPositionBeforeBlock()` has a `> batchStart` comparison when it should have a `>= batchStart` comparison.

Additionally, I updated TypeScript to 5.4 and was able to now use the `isDefined()` helper as intended.

## Tests

- Unit tests: pass
- Integration tests V2: this makes one new assertion pass, although not the whole test suite