### PR TITLE
Remove IndexedDB in-memory cache

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -31,17 +31,6 @@ type LevelWithIndexedDB = {
       location: string;
       db: IDBDatabase;
     };
-    codec: {
-      encodings: Record<
-        string,
-        {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          encode: (value: any) => ArrayBuffer;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          decode: (value: ArrayBuffer) => any;
-        }
-      >;
-    };
   };
 };
 
@@ -59,10 +48,6 @@ type DatabaseWithIndexedDB = Database & {
 class Database {
   readonly level: LevelUp & MaybeIndexedDB;
 
-  private preloaded: Promise<void> | undefined;
-
-  private preloadedMap: Map<string, ArrayBuffer> | undefined;
-
   private isClearingNamespace: boolean = false;
 
   /**
@@ -78,60 +63,8 @@ class Database {
     return this.level.isClosed();
   }
 
-  /**
-   * If the database is IndexedDB, preload all keys and values into memory, as a
-   * cache. Otherwise, does nothing.
-   */
-  async preload() {
-    if (!this.usesIndexedDB()) return;
-
-    this.preloaded ??= new Promise((resolve, reject) => {
-      if (!this.usesIndexedDB()) return;
-      const store = this.getIndexedDBStore();
-      let preloadedKeys: ArrayBuffer[] | undefined;
-      let preloadedValues: ArrayBuffer[] | undefined;
-
-      // Combine keys and values together into a Map
-      const done = () => {
-        this.preloadedMap = new Map();
-        if (!preloadedKeys) return;
-        if (!preloadedValues) return;
-        for (let i = 0; i < preloadedKeys.length; i += 1) {
-          const key = new TextDecoder().decode(preloadedKeys[i]);
-          this.preloadedMap.set(key, preloadedValues[i]);
-        }
-        preloadedKeys = undefined;
-        preloadedValues = undefined;
-        resolve();
-      };
-
-      // Load all keys into memory
-      const keysRequest = store.getAllKeys();
-      keysRequest.onsuccess = (ev: Event) => {
-        preloadedKeys = (ev.target as IDBRequest<ArrayBuffer[]>).result;
-        if (typeof preloadedValues !== 'undefined') done();
-      };
-      keysRequest.onerror = (ev: Event) => {
-        reject((ev.target as IDBRequest).error);
-      };
-
-      // Load all values into memory
-      const valuesRequest = store.getAll();
-      valuesRequest.onsuccess = (ev: Event) => {
-        preloadedValues = (ev.target as IDBRequest<ArrayBuffer[]>).result;
-        if (typeof preloadedKeys !== 'undefined') done();
-      };
-      valuesRequest.onerror = (ev: Event) => {
-        reject((ev.target as IDBRequest).error);
-      };
-    });
-    await this.preloaded;
-  }
-
   private usesIndexedDB(): this is DatabaseWithIndexedDB {
-    return (
-      typeof indexedDB !== 'undefined' && typeof this.level.db?.db?.db !== 'undefined' && false
-    ); // TODO: Profile indexedDB changes against older devices, then remove false
+    return typeof indexedDB !== 'undefined' && typeof this.level.db?.db?.db !== 'undefined';
   }
 
   private getIndexedDBStore(this: DatabaseWithIndexedDB): IDBObjectStore {
@@ -152,34 +85,6 @@ class Database {
   }
 
   /**
-   *
-   * @param value - value to encode
-   * @param encoding - data encoding to use
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private encode(this: DatabaseWithIndexedDB, value: any, encoding: Encoding): ArrayBuffer {
-    const { encodings } = this.level.db.codec;
-    if (typeof encodings[encoding] === 'undefined') throw new Error(`Unknown encoding ${encoding}`);
-    return encodings[encoding].encode(value);
-  }
-
-  /**
-   * @param value - value to decode
-   * @param encoding - data encoding to use
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private decode(this: DatabaseWithIndexedDB, value: ArrayBuffer, encoding: Encoding): any {
-    const { encodings } = this.level.db.codec;
-    if (typeof encodings[encoding] === 'undefined') throw new Error(`Unknown encoding ${encoding}`);
-    // Special case for decoding already-decoded JSON objects:
-    if (encoding === 'json' && !ArrayBuffer.isView(value) && typeof value === 'object') {
-      return value;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return encodings[encoding].decode(Buffer.from(value));
-  }
-
-  /**
    * Set value in database
    * @param path - database path
    * @param value - value to set
@@ -196,13 +101,6 @@ class Database {
         EngineDebug.log('Database is clearing a namespace - put action is dangerous');
       }
       const key = Database.pathToKey(path);
-      try {
-        if (this.usesIndexedDB() && this.preloadedMap) {
-          this.preloadedMap.set(key, this.encode(value, encoding));
-        }
-      } catch {
-        // ignore
-      }
       await this.level.put(key, value, { valueEncoding: encoding });
     } catch (cause) {
       if (!(cause instanceof Error)) {
@@ -224,18 +122,6 @@ class Database {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get(path: Path, encoding: Encoding = 'hex'): Promise<any> {
     const key = Database.pathToKey(path);
-    if (this.usesIndexedDB() && this.preloadedMap) {
-      const value = this.preloadedMap.get(key);
-      if (!value) return Promise.reject(new Error('NotFound'));
-      let decoded;
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        decoded = this.decode(value, encoding);
-      } catch (err) {
-        return Promise.reject(err);
-      }
-      return Promise.resolve(decoded);
-    }
     return this.level.get(key, { valueEncoding: encoding });
   }
 
@@ -247,9 +133,6 @@ class Database {
    */
   del(path: Path, encoding: Encoding = 'hex'): Promise<void> {
     const key = Database.pathToKey(path);
-    if (this.preloadedMap) {
-      this.preloadedMap.delete(key);
-    }
     return this.level.del(key, { valueEncoding: encoding });
   }
 
@@ -266,18 +149,6 @@ class Database {
       }
       if (this.isClearingNamespace) {
         EngineDebug.log('Database is clearing a namespace - batch action is dangerous');
-      }
-      if (this.usesIndexedDB() && this.preloadedMap) {
-        ops.forEach((op) => {
-          if (op.type === 'put') {
-            this.preloadedMap?.set(
-              op.key as string,
-              (this as DatabaseWithIndexedDB).encode(op.value, encoding),
-            );
-          } else if (op.type === 'del') {
-            this.preloadedMap?.delete(op.key as string);
-          }
-        });
       }
       await this.level.batch(ops, { valueEncoding: encoding });
     } catch (cause) {
@@ -385,13 +256,6 @@ class Database {
       this.isClearingNamespace = true;
       const pathkey = Database.pathToKey(namespace);
       EngineDebug.log(`Clearing namespace: ${pathkey}`);
-      if (this.preloadedMap) {
-        this.preloadedMap.forEach((_, key) => {
-          if (key.startsWith(pathkey)) {
-            this.preloadedMap?.delete(key);
-          }
-        });
-      }
       await this.level.clear({
         gte: `${pathkey}`,
         lte: `${pathkey}~`,

--- a/src/merkletree/merkletree.ts
+++ b/src/merkletree/merkletree.ts
@@ -93,12 +93,6 @@ export abstract class Merkletree<T extends MerkletreeLeaf> {
   }
 
   protected async init(): Promise<void> {
-    await this.db.preload().catch((err: Error) => {
-      EngineDebug.log(
-        `Warning. Merkletree failed to preload database: ${err.message ?? err}. ` +
-          'Queries may be slower.',
-      );
-    });
     await this.getMetadataFromStorage();
   }
 


### PR DESCRIPTION
## Context

The [IndexedDB optimizations](https://github.com/Railgun-Community/engine/commit/bee8d564fd62994a95588daa5ae35be5db35f174#diff-b142db61bad18069d76738bcf176fc5d8cb04c0e4092219724b00ac53b728ecc) introduced some tradeoffs related to loading the whole database in memory, such as longer startup time on wallet apps.

## Problem

Benchmarks show that the in-memory cache (`preloadedMap`) speeds up only some very specific use cases, but has no effect, or negatively impact other use cases.

## Solution

This PR removes the `preloadedMap` optimization.

**However,** there is another IndexedDB optimization worth keeping, which is in `getNamespaceKeys` and `countNamespace`, using IndexedDB's `getAllKeys` API that only visits the db entries that we want. Those optimizations have no detectable downside in performance benchmarks.

## Tests

- ✅ Passes unit tests