### PR TITLE
Improve timeout period for loadNetwork providers

### DIFF
--- a/src/railgun-engine.ts
+++ b/src/railgun-engine.ts
@@ -1517,7 +1517,7 @@ class RailgunEngine extends EventEmitter {
     try {
       await promiseTimeout(
         defaultProvider.getBlockNumber(),
-        10000,
+        60_000,
         'Timed out waiting for default RPC provider to connect.',
       );
     } catch (cause) {
@@ -1533,7 +1533,7 @@ class RailgunEngine extends EventEmitter {
     try {
       await promiseTimeout(
         pollingProvider.getBlockNumber(),
-        10000,
+        60_000,
         'Timed out waiting for polling RPC provider to connect.',
       );
     } catch (cause) {


### PR DESCRIPTION
Some apps were getting the timeout error, and 10s seemed a bit too tight, so I bumped this number up to 60s and this has fixed the problem.