### PR TITLE
Replace nested arrays with Registry data structure

### DIFF
--- a/src/__tests__/railgun-engine.test.ts
+++ b/src/__tests__/railgun-engine.test.ts
@@ -453,7 +453,7 @@ describe('railgun-engine', function test() {
     const creationBlockNumbers: number[][] = [];
     creationBlockNumbers[chain.type] = [];
     creationBlockNumbers[chain.type][chain.id] = 0;
-    wallet.setCreationBlockNumbers(creationBlockNumbers);
+    wallet.testSpecificSetCreationBlockNumbers(creationBlockNumbers);
 
     const commitment: LegacyGeneratedCommitment = {
       commitmentType: CommitmentType.LegacyGeneratedCommitment,

--- a/src/contracts/contract-store.ts
+++ b/src/contracts/contract-store.ts
@@ -1,4 +1,5 @@
 import { Chain } from '../models/engine-types';
+import { Registry } from '../utils/registry';
 import { RailgunSmartWalletContract } from './railgun-smart-wallet/V2/railgun-smart-wallet';
 import { PoseidonMerkleAccumulatorContract } from './railgun-smart-wallet/V3/poseidon-merkle-accumulator';
 import { PoseidonMerkleVerifierContract } from './railgun-smart-wallet/V3/poseidon-merkle-verifier';
@@ -7,63 +8,18 @@ import { RelayAdaptV2Contract } from './relay-adapt/V2/relay-adapt-v2';
 import { RelayAdaptV3Contract } from './relay-adapt/V3/relay-adapt-v3';
 
 export class ContractStore {
-  static readonly railgunSmartWalletContracts: RailgunSmartWalletContract[][] = [];
+  static readonly railgunSmartWalletContracts: Registry<RailgunSmartWalletContract> =
+    new Registry();
 
-  static readonly relayAdaptV2Contracts: RelayAdaptV2Contract[][] = [];
+  static readonly relayAdaptV2Contracts: Registry<RelayAdaptV2Contract> = new Registry();
 
-  static readonly poseidonMerkleAccumulatorV3Contracts: PoseidonMerkleAccumulatorContract[][] = [];
+  static readonly poseidonMerkleAccumulatorV3Contracts: Registry<PoseidonMerkleAccumulatorContract> =
+    new Registry();
 
-  static readonly poseidonMerkleVerifierV3Contracts: PoseidonMerkleVerifierContract[][] = [];
+  static readonly poseidonMerkleVerifierV3Contracts: Registry<PoseidonMerkleVerifierContract> =
+    new Registry();
 
-  static readonly tokenVaultV3Contracts: TokenVaultContract[][] = [];
+  static readonly tokenVaultV3Contracts: Registry<TokenVaultContract> = new Registry();
 
-  static readonly relayAdaptV3Contracts: RelayAdaptV3Contract[][] = [];
-
-  static getRailgunSmartWalletContract(chain: Chain): RailgunSmartWalletContract {
-    try {
-      return this.railgunSmartWalletContracts[chain.type][chain.id];
-    } catch (cause) {
-      throw new Error('No RailgunSmartWalletContract loaded.', { cause });
-    }
-  }
-
-  static getRelayAdaptV2Contract(chain: Chain): RelayAdaptV2Contract {
-    try {
-      return this.relayAdaptV2Contracts[chain.type][chain.id];
-    } catch (cause) {
-      throw new Error('No RelayAdaptV2Contract loaded.', { cause });
-    }
-  }
-
-  static getRelayAdaptV3Contract(chain: Chain): RelayAdaptV3Contract {
-    try {
-      return this.relayAdaptV3Contracts[chain.type][chain.id];
-    } catch (cause) {
-      throw new Error('No RelayAdaptV3Contract loaded.', { cause });
-    }
-  }
-
-  static getPoseidonMerkleAccumulatorV3Contract(chain: Chain): PoseidonMerkleAccumulatorContract {
-    try {
-      return this.poseidonMerkleAccumulatorV3Contracts[chain.type][chain.id];
-    } catch (cause) {
-      throw new Error('No PoseidonMerkleAccumulatorV3Contract loaded.', { cause });
-    }
-  }
-
-  static getPoseidonMerkleVerifierV3Contract(chain: Chain): PoseidonMerkleVerifierContract {
-    try {
-      return this.poseidonMerkleVerifierV3Contracts[chain.type][chain.id];
-    } catch (cause) {
-      throw new Error('No PoseidonMerkleVerifierV3Contract loaded.', { cause });
-    }
-  }
-
-  static getTokenVaultV3Contract(chain: Chain): TokenVaultContract {
-    try {
-      return this.tokenVaultV3Contracts[chain.type][chain.id];
-    } catch (cause) {
-      throw new Error('No TokenVaultV3Contract loaded.', { cause });
-    }
-  }
+  static readonly relayAdaptV3Contracts: Registry<RelayAdaptV3Contract> = new Registry();
 }

--- a/src/contracts/railgun-smart-wallet/railgun-versioned-smart-contracts.ts
+++ b/src/contracts/railgun-smart-wallet/railgun-versioned-smart-contracts.ts
@@ -26,13 +26,10 @@ export class RailgunVersionedSmartContracts {
   static getAccumulator(txidVersion: TXIDVersion, chain: Chain) {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRailgunSmartWalletContract(chain);
-        return contractV2;
+        return ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain);
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3PoseidonMerkleAccumulator =
-          ContractStore.getPoseidonMerkleAccumulatorV3Contract(chain);
-        return contractV3PoseidonMerkleAccumulator;
+        return ContractStore.poseidonMerkleAccumulatorV3Contracts.getOrThrow(null, chain);
       }
     }
     throw new Error('Unsupported txidVersion');
@@ -41,13 +38,11 @@ export class RailgunVersionedSmartContracts {
   static getVerifier(txidVersion: TXIDVersion, chain: Chain) {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRailgunSmartWalletContract(chain);
+        const contractV2 = ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain);
         return contractV2;
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3PoseidonMerkleVerifier =
-          ContractStore.getPoseidonMerkleVerifierV3Contract(chain);
-        return contractV3PoseidonMerkleVerifier;
+        return ContractStore.poseidonMerkleVerifierV3Contracts.getOrThrow(null, chain);
       }
     }
     throw new Error('Unsupported txidVersion');
@@ -56,12 +51,10 @@ export class RailgunVersionedSmartContracts {
   static getShieldApprovalContract(txidVersion: TXIDVersion, chain: Chain) {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRailgunSmartWalletContract(chain);
-        return contractV2;
+        return ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain);
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3TokenVault = ContractStore.getTokenVaultV3Contract(chain);
-        return contractV3TokenVault;
+        return ContractStore.tokenVaultV3Contracts.getOrThrow(null, chain);
       }
     }
     throw new Error('Unsupported txidVersion');
@@ -70,12 +63,10 @@ export class RailgunVersionedSmartContracts {
   static getRelayAdaptContract(txidVersion: TXIDVersion, chain: Chain) {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRelayAdaptV2Contract(chain);
-        return contractV2;
+        return ContractStore.relayAdaptV2Contracts.getOrThrow(null, chain);
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3TokenVault = ContractStore.getRelayAdaptV3Contract(chain);
-        return contractV3TokenVault;
+        return ContractStore.relayAdaptV3Contracts.getOrThrow(null, chain);
       }
     }
     throw new Error('Unsupported txidVersion');
@@ -95,7 +86,7 @@ export class RailgunVersionedSmartContracts {
   ) {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRailgunSmartWalletContract(chain);
+        const contractV2 = ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain);
         return contractV2.getHistoricalEvents(
           initialStartBlock,
           latestBlock,
@@ -107,9 +98,11 @@ export class RailgunVersionedSmartContracts {
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3PoseidonMerkleAccumulator =
-          ContractStore.getPoseidonMerkleAccumulatorV3Contract(chain);
-        return contractV3PoseidonMerkleAccumulator.getHistoricalEvents(
+        const contractV3 = ContractStore.poseidonMerkleAccumulatorV3Contracts.getOrThrow(
+          null,
+          chain,
+        );
+        return contractV3.getHistoricalEvents(
           initialStartBlock,
           latestBlock,
           getNextStartBlockFromValidMerkletree,
@@ -135,7 +128,7 @@ export class RailgunVersionedSmartContracts {
   ) {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRailgunSmartWalletContract(chain);
+        const contractV2 = ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain);
         return contractV2.setTreeUpdateListeners(
           eventsCommitmentListener,
           eventsNullifierListener,
@@ -143,9 +136,11 @@ export class RailgunVersionedSmartContracts {
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3PoseidonMerkleAccumulator =
-          ContractStore.getPoseidonMerkleAccumulatorV3Contract(chain);
-        return contractV3PoseidonMerkleAccumulator.setTreeUpdateListeners(
+        const contractV3 = ContractStore.poseidonMerkleAccumulatorV3Contracts.getOrThrow(
+          null,
+          chain,
+        );
+        return contractV3.setTreeUpdateListeners(
           eventsCommitmentListener,
           eventsNullifierListener,
           eventsUnshieldListener,
@@ -163,11 +158,11 @@ export class RailgunVersionedSmartContracts {
   ): Promise<{ shield: bigint; unshield: bigint }> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRailgunSmartWalletContract(chain);
+        const contractV2 = ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain);
         return contractV2.fees();
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractTokenVaultV3 = ContractStore.getTokenVaultV3Contract(chain);
+        const contractTokenVaultV3 = ContractStore.tokenVaultV3Contracts.getOrThrow(null, chain);
         return contractTokenVaultV3.fees();
       }
     }
@@ -181,11 +176,11 @@ export class RailgunVersionedSmartContracts {
   ): Promise<TokenDataStructOutput> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRailgunSmartWalletContract(chain);
+        const contractV2 = ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain);
         return contractV2.getNFTTokenData(tokenHash);
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractTokenVaultV3 = ContractStore.getTokenVaultV3Contract(chain);
+        const contractTokenVaultV3 = ContractStore.tokenVaultV3Contracts.getOrThrow(null, chain);
         return contractTokenVaultV3.getNFTTokenData(tokenHash);
       }
     }
@@ -199,13 +194,13 @@ export class RailgunVersionedSmartContracts {
   ): Promise<ContractTransaction> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRailgunSmartWalletContract(chain);
+        const contractV2 = ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain);
         return contractV2.generateShield(shieldRequests);
       }
 
       case TXIDVersion.V3_PoseidonMerkle: {
         const contractV3PoseidonMerkleVerifier =
-          ContractStore.getPoseidonMerkleVerifierV3Contract(chain);
+          ContractStore.poseidonMerkleVerifierV3Contracts.getOrThrow(null, chain);
         const emptyGlobalBoundParams: PoseidonMerkleVerifier.GlobalBoundParamsStruct = {
           minGasPrice: 0n,
           chainID: chain.id,
@@ -231,7 +226,7 @@ export class RailgunVersionedSmartContracts {
   ): Promise<ContractTransaction> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRailgunSmartWalletContract(chain);
+        const contractV2 = ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain);
         return contractV2.generateTransact(transactions as TransactionStructV2[]);
       }
 
@@ -245,7 +240,7 @@ export class RailgunVersionedSmartContracts {
         }
         const globalBoundParams = (transactions[0] as TransactionStructV3).boundParams.global;
         const contractV3PoseidonMerkleVerifier =
-          ContractStore.getPoseidonMerkleVerifierV3Contract(chain);
+          ContractStore.poseidonMerkleVerifierV3Contracts.getOrThrow(null, chain);
         return contractV3PoseidonMerkleVerifier.generateExecute(
           transactionsV3,
           [],

--- a/src/contracts/relay-adapt/relay-adapt-versioned-smart-contracts.ts
+++ b/src/contracts/relay-adapt/relay-adapt-versioned-smart-contracts.ts
@@ -11,12 +11,10 @@ export class RelayAdaptVersionedSmartContracts {
   static getRelayAdaptContract(txidVersion: TXIDVersion, chain: Chain) {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRelayAdaptV2Contract(chain);
-        return contractV2;
+        return ContractStore.relayAdaptV2Contracts.getOrThrow(null, chain);
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3PoseidonMerkleAccumulator = ContractStore.getRelayAdaptV3Contract(chain);
-        return contractV3PoseidonMerkleAccumulator;
+        return ContractStore.relayAdaptV3Contracts.getOrThrow(null, chain);
       }
     }
     throw new Error('Unsupported txidVersion');
@@ -39,7 +37,7 @@ export class RelayAdaptVersionedSmartContracts {
   ): Promise<ContractTransaction> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRelayAdaptV2Contract(chain);
+        const contractV2 = ContractStore.relayAdaptV2Contracts.getOrThrow(null, chain);
         return contractV2.populateUnshieldBaseToken(
           transactions as TransactionStructV2[],
           unshieldAddress,
@@ -47,7 +45,7 @@ export class RelayAdaptVersionedSmartContracts {
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3 = ContractStore.getRelayAdaptV3Contract(chain);
+        const contractV3 = ContractStore.relayAdaptV3Contracts.getOrThrow(null, chain);
         return contractV3.populateUnshieldBaseToken(
           transactions as TransactionStructV2[],
           unshieldAddress,
@@ -71,7 +69,7 @@ export class RelayAdaptVersionedSmartContracts {
   ): Promise<ContractTransaction> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRelayAdaptV2Contract(chain);
+        const contractV2 = ContractStore.relayAdaptV2Contracts.getOrThrow(null, chain);
         return contractV2.populateCrossContractCalls(
           unshieldTransactions as TransactionStructV2[],
           crossContractCalls,
@@ -83,7 +81,7 @@ export class RelayAdaptVersionedSmartContracts {
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3 = ContractStore.getRelayAdaptV3Contract(chain);
+        const contractV3 = ContractStore.relayAdaptV3Contracts.getOrThrow(null, chain);
         return contractV3.populateCrossContractCalls(
           unshieldTransactions as TransactionStructV2[],
           crossContractCalls,
@@ -107,7 +105,7 @@ export class RelayAdaptVersionedSmartContracts {
   ): Promise<string> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRelayAdaptV2Contract(chain);
+        const contractV2 = ContractStore.relayAdaptV2Contracts.getOrThrow(null, chain);
         return contractV2.getRelayAdaptParamsUnshieldBaseToken(
           dummyUnshieldTransactions as TransactionStructV2[],
           unshieldAddress,
@@ -115,7 +113,7 @@ export class RelayAdaptVersionedSmartContracts {
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3 = ContractStore.getRelayAdaptV3Contract(chain);
+        const contractV3 = ContractStore.relayAdaptV3Contracts.getOrThrow(null, chain);
         return contractV3.getRelayAdaptParamsUnshieldBaseToken(
           dummyUnshieldTransactions as TransactionStructV2[],
           unshieldAddress,
@@ -138,7 +136,7 @@ export class RelayAdaptVersionedSmartContracts {
   ): Promise<string> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
-        const contractV2 = ContractStore.getRelayAdaptV2Contract(chain);
+        const contractV2 = ContractStore.relayAdaptV2Contracts.getOrThrow(null, chain);
         return contractV2.getRelayAdaptParamsCrossContractCalls(
           dummyUnshieldTransactions as TransactionStructV2[],
           crossContractCalls,
@@ -149,7 +147,7 @@ export class RelayAdaptVersionedSmartContracts {
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {
-        const contractV3 = ContractStore.getRelayAdaptV3Contract(chain);
+        const contractV3 = ContractStore.relayAdaptV3Contracts.getOrThrow(null, chain);
         return contractV3.getRelayAdaptParamsCrossContractCalls(
           dummyUnshieldTransactions as TransactionStructV2[],
           crossContractCalls,

--- a/src/merkletree/__tests__/txid-merkletree.test.ts
+++ b/src/merkletree/__tests__/txid-merkletree.test.ts
@@ -40,7 +40,7 @@ describe('txid-merkletree', () => {
     // Create database
     db = new Database(memdown());
 
-    POI.setLaunchBlock(chain, poiLaunchBlock);
+    POI.launchBlocks.set(null, chain, poiLaunchBlock);
 
     merkletreePOINode = await TXIDMerkletree.createForPOINode(db, chain, txidVersion);
     expect(merkletreePOINode.shouldStoreMerkleroots).to.equal(true);
@@ -63,8 +63,8 @@ describe('txid-merkletree', () => {
       result: string[];
     };
 
-    POI.setLaunchBlock({ type: ChainType.EVM, id: 0 }, 10);
-    POI.setLaunchBlock({ type: ChainType.EVM, id: 4 }, 11);
+    POI.launchBlocks.set(null, { type: ChainType.EVM, id: 0 }, 10);
+    POI.launchBlocks.set(null, { type: ChainType.EVM, id: 4 }, 11);
 
     const vectors: Vector[] = [
       {

--- a/src/merkletree/txid-merkletree.ts
+++ b/src/merkletree/txid-merkletree.ts
@@ -151,7 +151,7 @@ export class TXIDMerkletree extends Merkletree<RailgunTransactionWithHash> {
 
     // Use the snapshot if this is a legacy transaction, and we have a snapshot.
     // (Ie., after POI has launched for this chain).
-    const poiLaunchBlock = POI.getLaunchBlock(this.chain);
+    const poiLaunchBlock = POI.launchBlocks.get(null, this.chain);
     const useSnapshot =
       isDefined(poiLaunchBlock) &&
       this.shouldSavePOILaunchSnapshot &&
@@ -357,7 +357,7 @@ export class TXIDMerkletree extends Merkletree<RailgunTransactionWithHash> {
       return;
     }
 
-    const poiLaunchBlock = POI.getLaunchBlock(this.chain);
+    const poiLaunchBlock = POI.launchBlocks.get(null, this.chain);
     if (!isDefined(poiLaunchBlock)) {
       return;
     }

--- a/src/note/__tests__/transact-note.test.ts
+++ b/src/note/__tests__/transact-note.test.ts
@@ -325,18 +325,23 @@ describe('transact-note', () => {
     WalletInfo.setWalletSource('tester');
 
     // Load fake contracts
-    ContractStore.railgunSmartWalletContracts[chain.type] = [];
-    ContractStore.railgunSmartWalletContracts[chain.type][chain.id] =
+    ContractStore.railgunSmartWalletContracts.set(
+      null,
+      chain,
       new RailgunSmartWalletContract(
         config.contracts.proxy,
         new PollingJsonRpcProvider(config.rpc, 1, 500, 1),
         new PollingJsonRpcProvider(config.rpc, 1, 500, 1),
         chain,
-      );
-    ContractStore.tokenVaultV3Contracts[chain.type] = [];
-    ContractStore.tokenVaultV3Contracts[chain.type][chain.id] = new TokenVaultContract(
-      config.contracts.poseidonMerkleVerifierV3,
-      new PollingJsonRpcProvider(config.rpc, 1, 500, 1),
+      ),
+    );
+    ContractStore.tokenVaultV3Contracts.set(
+      null,
+      chain,
+      new TokenVaultContract(
+        config.contracts.poseidonMerkleVerifierV3,
+        new PollingJsonRpcProvider(config.rpc, 1, 500, 1),
+      ),
     );
 
     tokenDataGetter = new TokenDataGetter(db);

--- a/src/poi/__tests__/poi.test.ts
+++ b/src/poi/__tests__/poi.test.ts
@@ -88,7 +88,7 @@ describe('poi', () => {
       ],
       new TestPOINodeInterface(),
     );
-    POI.setLaunchBlock(chain, 0);
+    POI.launchBlocks.set(null, chain, 0);
   });
 
   after(() => {

--- a/src/poi/poi-status-formatter.ts
+++ b/src/poi/poi-status-formatter.ts
@@ -183,7 +183,7 @@ const formatSpentStatusInfo = async (
         .map((hex) => emojiHashForPOIStatusInfo(hex))
         .join(', ')} (${hasAllCom ? '✓' : 'x'})`;
 
-      const poiLaunchBlock = POI.getLaunchBlock(txidMerkletree.chain);
+      const poiLaunchBlock = POI.launchBlocks.get(null, txidMerkletree.chain);
       if (!isDefined(poiLaunchBlock)) {
         throw new Error('No POI launch block for railgun txids');
       }

--- a/src/poi/poi.ts
+++ b/src/poi/poi.ts
@@ -15,6 +15,7 @@ import { POINodeInterface } from './poi-node-interface';
 import { UnshieldStoredEvent } from '../models/event-types';
 import { OutputType } from '../models';
 import { isShieldCommitmentType, isTransactCommitmentType } from '../utils/commitment';
+import { Registry } from '../utils/registry';
 
 export type POIList = {
   key: string;
@@ -33,20 +34,11 @@ export class POI {
 
   private static nodeInterface: POINodeInterface;
 
-  private static launchBlocks: number[][] = [];
+  static launchBlocks: Registry<number> = new Registry();
 
   static init(lists: POIList[], nodeInterface: POINodeInterface) {
     this.lists = lists;
     this.nodeInterface = nodeInterface;
-  }
-
-  static setLaunchBlock(chain: Chain, launchBlock: number) {
-    this.launchBlocks[chain.type] ??= [];
-    this.launchBlocks[chain.type][chain.id] = launchBlock;
-  }
-
-  static getLaunchBlock(chain: Chain): Optional<number> {
-    return this.launchBlocks[chain.type]?.[chain.id];
   }
 
   static getAllListKeys(): string[] {
@@ -210,7 +202,7 @@ export class POI {
   }
 
   static isLegacyTXO(chain: Chain, txo: TXO) {
-    const launchBlock = this.getLaunchBlock(chain);
+    const launchBlock = this.launchBlocks.get(null, chain);
     if (!isDefined(launchBlock) || txo.blockNumber < launchBlock) {
       return true;
     }

--- a/src/prover/__tests__/prover.test.ts
+++ b/src/prover/__tests__/prover.test.ts
@@ -33,7 +33,7 @@ const chain: Chain = {
 describe('prover', () => {
   beforeEach(() => {
     ProofCachePOI.clear_TEST_ONLY();
-    POI.setLaunchBlock(chain, 0);
+    POI.launchBlocks.set(null, chain, 0);
   });
 
   it('Should generate and validate POI proof - 3x3', async () => {

--- a/src/railgun-engine.ts
+++ b/src/railgun-engine.ts
@@ -1648,7 +1648,7 @@ class RailgunEngine extends EventEmitter {
 
       if (isDefined(poiLaunchBlock) || supportsV3) {
         if (isDefined(poiLaunchBlock)) {
-          POI.setLaunchBlock(chain, poiLaunchBlock);
+          POI.launchBlocks.set(null, chain, poiLaunchBlock);
         }
 
         if (this.isPOINode) {

--- a/src/railgun-engine.ts
+++ b/src/railgun-engine.ts
@@ -84,7 +84,7 @@ class RailgunEngine extends EventEmitter {
 
   readonly wallets: { [key: string]: AbstractWallet } = {};
 
-  readonly deploymentBlocks: { [txidVersion: string]: number[][] } = {};
+  readonly deploymentBlocks: Registry<number> = new Registry();
 
   readonly quickSyncEvents: QuickSyncEvents;
 
@@ -98,7 +98,7 @@ class RailgunEngine extends EventEmitter {
 
   private readonly skipMerkletreeScans: boolean;
 
-  private readonly pollingRailgunTransactionsV2: boolean[][] = [];
+  private readonly pollingRailgunTransactionsV2: Registry<boolean> = new Registry();
 
   readonly isPOINode: boolean;
 
@@ -360,8 +360,10 @@ class RailgunEngine extends EventEmitter {
     chain: Chain,
   ): Promise<Optional<number>> {
     const utxoMerkletree = this.getUTXOMerkletree(txidVersion, chain);
-    const railgunSmartWalletContract =
-      ContractStore.railgunSmartWalletContracts[chain.type]?.[chain.id];
+    const railgunSmartWalletContract = ContractStore.railgunSmartWalletContracts.get(null, chain);
+    if (!isDefined(railgunSmartWalletContract)) {
+      throw new Error('No RailgunSmartWalletContract loaded.');
+    }
     const provider = railgunSmartWalletContract.contract.runner?.provider;
     if (!provider) {
       throw new Error('Requires provider for commitment block lookup');
@@ -411,7 +413,7 @@ class RailgunEngine extends EventEmitter {
     );
     if (startScanningBlock == null) {
       // If we haven't scanned anything yet, start scanning at deployment block
-      startScanningBlock = this.deploymentBlocks[txidVersion]?.[chain.type]?.[chain.id];
+      startScanningBlock = this.deploymentBlocks.get(txidVersion, chain);
       if (!isDefined(startScanningBlock)) {
         throw new Error(
           `Deployment block not defined for ${txidVersion} and chain ${chain.type}:${chain.id}`,
@@ -536,7 +538,7 @@ class RailgunEngine extends EventEmitter {
       await this.scanEventHistory(txidVersion, chain, walletIdFilter);
     }
 
-    if (this.pollingRailgunTransactionsV2[chain.type]?.[chain.id] !== true) {
+    if (this.pollingRailgunTransactionsV2.get(null, chain) !== true) {
       await this.startSyncRailgunTransactionsPollerV2(chain);
     }
   }
@@ -556,7 +558,7 @@ class RailgunEngine extends EventEmitter {
       );
       return;
     }
-    if (!isDefined(ContractStore.railgunSmartWalletContracts[chain.type]?.[chain.id])) {
+    if (!isDefined(ContractStore.railgunSmartWalletContracts.get(null, chain))) {
       EngineDebug.log(
         `Cannot scan history. Proxy contract not yet loaded for chain ${chain.type}:${chain.id}.`,
       );
@@ -595,10 +597,9 @@ class RailgunEngine extends EventEmitter {
       `[${txidVersion}] startScanningBlockSlowScan: ${startScanningBlockSlowScan} (note: continously updated during scan)`,
     );
 
-    const railgunSmartWalletContract =
-      ContractStore.railgunSmartWalletContracts[chain.type]?.[chain.id];
-    if (!railgunSmartWalletContract.contract.runner?.provider) {
-      throw new Error('Requires provider for RailgunSmartWallet contract');
+    const railgunSmartWalletContract = ContractStore.railgunSmartWalletContracts.get(null, chain);
+    if (!railgunSmartWalletContract?.contract.runner?.provider) {
+      throw new Error('Requires RailgunSmartWalletContract with provider');
     }
     const latestBlock = await railgunSmartWalletContract.contract.runner.provider.getBlockNumber();
 
@@ -692,8 +693,7 @@ class RailgunEngine extends EventEmitter {
   ) {
     const txidVersion = TXIDVersion.V2_PoseidonMerkle;
 
-    const railgunSmartWalletContract =
-      ContractStore.railgunSmartWalletContracts[chain.type]?.[chain.id];
+    const railgunSmartWalletContract = ContractStore.railgunSmartWalletContracts.get(null, chain);
     if (!isDefined(railgunSmartWalletContract)) {
       throw new Error('Requires RailgunSmartWallet contract');
     }
@@ -748,7 +748,7 @@ class RailgunEngine extends EventEmitter {
     const txidVersion = TXIDVersion.V3_PoseidonMerkle;
 
     const poseidonMerkleAccumulatorV3Contract =
-      ContractStore.poseidonMerkleAccumulatorV3Contracts[chain.type]?.[chain.id];
+      ContractStore.poseidonMerkleAccumulatorV3Contracts.get(null, chain);
     if (!isDefined(poseidonMerkleAccumulatorV3Contract)) {
       throw new Error('Requires V3PoseidonMerkleAccumulator contract');
     }
@@ -809,8 +809,7 @@ class RailgunEngine extends EventEmitter {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.syncRailgunTransactionsPollerV2(chain, refreshDelayMsec);
 
-    this.pollingRailgunTransactionsV2[chain.type] ??= [];
-    this.pollingRailgunTransactionsV2[chain.type][chain.id] = true;
+    this.pollingRailgunTransactionsV2.set(null, chain, true);
   }
 
   private async syncRailgunTransactionsPollerV2(chain: Chain, refreshDelayMsec: number) {
@@ -1414,7 +1413,7 @@ class RailgunEngine extends EventEmitter {
     if (!this.hasTXIDMerkletree(txidVersion, chain)) {
       return;
     }
-    if (this.pollingRailgunTransactionsV2[chain.type]?.[chain.id] !== true) {
+    if (this.pollingRailgunTransactionsV2.get(null, chain) !== true) {
       const err = new Error(
         `Cannot re-scan railgun txids. Must get UTXO history first. Please wait and try again.`,
       );
@@ -1481,14 +1480,18 @@ class RailgunEngine extends EventEmitter {
   ) {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle:
-        return ContractStore.railgunSmartWalletContracts[chain.type]?.[
-          chain.id
-        ]?.validateMerkleroot(tree, merkleroot);
+        return (
+          ContractStore.railgunSmartWalletContracts
+            .getOrThrow(null, chain)
+            .validateMerkleroot(tree, merkleroot)
+        );
 
       case TXIDVersion.V3_PoseidonMerkle:
-        return ContractStore.poseidonMerkleAccumulatorV3Contracts[chain.type]?.[
-          chain.id
-        ]?.validateMerkleroot(tree, merkleroot);
+        return (
+          ContractStore.poseidonMerkleAccumulatorV3Contracts
+            .getOrThrow(null, chain)
+            .validateMerkleroot(tree, merkleroot)
+        );
     }
     return false;
   }
@@ -1556,21 +1559,15 @@ class RailgunEngine extends EventEmitter {
       (txidVersion) =>
         !this.hasUTXOMerkletree(txidVersion, chain) && !this.hasTXIDMerkletree(txidVersion, chain),
     );
-    const hasSmartWalletContract = isDefined(
-      ContractStore.railgunSmartWalletContracts[chain.type]?.[chain.id],
+    const hasSmartWalletContract = ContractStore.railgunSmartWalletContracts.has(null, chain);
+    const hasRelayAdaptV2Contract = ContractStore.relayAdaptV2Contracts.has(null, chain);
+    const hasPoseidonMerkleAccumulatorV3Contract =
+      ContractStore.poseidonMerkleAccumulatorV3Contracts.has(null, chain);
+    const hasPoseidonMerkleVerifierV3Contract = ContractStore.poseidonMerkleVerifierV3Contracts.has(
+      null,
+      chain,
     );
-    const hasRelayAdaptV2Contract = isDefined(
-      ContractStore.relayAdaptV2Contracts[chain.type]?.[chain.id],
-    );
-    const hasPoseidonMerkleAccumulatorV3Contract = isDefined(
-      ContractStore.poseidonMerkleAccumulatorV3Contracts[chain.type]?.[chain.id],
-    );
-    const hasPoseidonMerkleVerifierV3Contract = isDefined(
-      ContractStore.poseidonMerkleVerifierV3Contracts[chain.type]?.[chain.id],
-    );
-    const hasTokenVaultV3Contract = isDefined(
-      ContractStore.tokenVaultV3Contracts[chain.type]?.[chain.id],
-    );
+    const hasTokenVaultV3Contract = ContractStore.tokenVaultV3Contracts.has(null, chain);
     if (
       hasAnyMerkletree ||
       hasSmartWalletContract ||
@@ -1584,39 +1581,45 @@ class RailgunEngine extends EventEmitter {
     }
 
     // Create contract instances
-    ContractStore.railgunSmartWalletContracts[chain.type] ??= [];
-    ContractStore.railgunSmartWalletContracts[chain.type][chain.id] =
+    ContractStore.railgunSmartWalletContracts.set(
+      null,
+      chain,
       new RailgunSmartWalletContract(
         railgunSmartWalletContractAddress,
         defaultProvider,
         pollingProvider,
         chain,
-      );
+      ),
+    );
 
-    ContractStore.relayAdaptV2Contracts[chain.type] ??= [];
-    ContractStore.relayAdaptV2Contracts[chain.type][chain.id] = new RelayAdaptV2Contract(
-      relayAdaptV2ContractAddress,
-      defaultProvider,
+    ContractStore.relayAdaptV2Contracts.set(
+      null,
+      chain,
+      new RelayAdaptV2Contract(relayAdaptV2ContractAddress, defaultProvider),
     );
 
     if (supportsV3) {
-      ContractStore.poseidonMerkleAccumulatorV3Contracts[chain.type] ??= [];
-      ContractStore.poseidonMerkleAccumulatorV3Contracts[chain.type][chain.id] =
+      ContractStore.poseidonMerkleAccumulatorV3Contracts.set(
+        null,
+        chain,
         new PoseidonMerkleAccumulatorContract(
           poseidonMerkleAccumulatorV3Address,
           defaultProvider,
           pollingProvider,
           chain,
-        );
+        ),
+      );
 
-      ContractStore.poseidonMerkleVerifierV3Contracts[chain.type] ??= [];
-      ContractStore.poseidonMerkleVerifierV3Contracts[chain.type][chain.id] =
-        new PoseidonMerkleVerifierContract(poseidonMerkleVerifierV3Address, defaultProvider);
+      ContractStore.poseidonMerkleVerifierV3Contracts.set(
+        null,
+        chain,
+        new PoseidonMerkleVerifierContract(poseidonMerkleVerifierV3Address, defaultProvider),
+      );
 
-      ContractStore.tokenVaultV3Contracts[chain.type] ??= [];
-      ContractStore.tokenVaultV3Contracts[chain.type][chain.id] = new TokenVaultContract(
-        tokenVaultV3Address,
-        defaultProvider,
+      ContractStore.tokenVaultV3Contracts.set(
+        null,
+        chain,
+        new TokenVaultContract(tokenVaultV3Address, defaultProvider),
       );
     }
 
@@ -1681,10 +1684,7 @@ class RailgunEngine extends EventEmitter {
         }
       }
 
-      // Set deployment block for txidVersion
-      this.deploymentBlocks[txidVersion] ??= [];
-      this.deploymentBlocks[txidVersion][chain.type] ??= [];
-      this.deploymentBlocks[txidVersion][chain.type][chain.id] = deploymentBlocks[txidVersion];
+      this.deploymentBlocks.set(txidVersion, chain, deploymentBlocks[txidVersion]);
     }
 
     if (this.skipMerkletreeScans) {
@@ -1732,11 +1732,9 @@ class RailgunEngine extends EventEmitter {
     const unshieldListener = async (txidVersion: TXIDVersion, unshields: UnshieldStoredEvent[]) => {
       await this.unshieldListener(txidVersion, chain, unshields);
     };
-    await ContractStore.railgunSmartWalletContracts[chain.type]?.[chain.id].setTreeUpdateListeners(
-      commitmentListener,
-      nullifierListener,
-      unshieldListener,
-    );
+    await ContractStore.railgunSmartWalletContracts
+      .get(null, chain)
+      ?.setTreeUpdateListeners(commitmentListener, nullifierListener, unshieldListener);
 
     if (supportsV3) {
       const railgunTransactionsV3Listener = async (
@@ -1772,15 +1770,15 @@ class RailgunEngine extends EventEmitter {
           );
         }
       };
-      await ContractStore.poseidonMerkleAccumulatorV3Contracts[chain.type][
-        chain.id
-      ].setTreeUpdateListeners(
-        commitmentListenerV3, // No wallet scans
-        nullifierListenerV3, // No wallet scans
-        unshieldListener,
-        railgunTransactionsV3Listener,
-        triggerWalletBalanceDecryptions,
-      );
+      await ContractStore.poseidonMerkleAccumulatorV3Contracts
+        .get(null, chain)
+        ?.setTreeUpdateListeners(
+          commitmentListenerV3, // No wallet scans
+          nullifierListenerV3, // No wallet scans
+          unshieldListener,
+          railgunTransactionsV3Listener,
+          triggerWalletBalanceDecryptions,
+        );
     }
   }
 
@@ -1789,7 +1787,7 @@ class RailgunEngine extends EventEmitter {
    * @param chain - chainID of network to unload
    */
   async unloadNetwork(chain: Chain): Promise<void> {
-    if (!isDefined(ContractStore.railgunSmartWalletContracts[chain.type]?.[chain.id])) {
+    if (ContractStore.railgunSmartWalletContracts.has(null, chain)) {
       return;
     }
 
@@ -1806,15 +1804,15 @@ class RailgunEngine extends EventEmitter {
     });
 
     // Unload listeners
-    await ContractStore.railgunSmartWalletContracts[chain.type]?.[chain.id].unload();
-    await ContractStore.poseidonMerkleAccumulatorV3Contracts[chain.type]?.[chain.id]?.unload();
+    await ContractStore.railgunSmartWalletContracts.get(null, chain)?.unload();
+    await ContractStore.poseidonMerkleAccumulatorV3Contracts.get(null, chain)?.unload();
 
     // Delete contracts
-    delete ContractStore.railgunSmartWalletContracts[chain.type]?.[chain.id];
-    delete ContractStore.relayAdaptV2Contracts[chain.type]?.[chain.id];
-    delete ContractStore.poseidonMerkleAccumulatorV3Contracts[chain.type]?.[chain.id];
-    delete ContractStore.poseidonMerkleVerifierV3Contracts[chain.type]?.[chain.id];
-    delete ContractStore.tokenVaultV3Contracts[chain.type]?.[chain.id];
+    ContractStore.railgunSmartWalletContracts.del(null, chain);
+    ContractStore.relayAdaptV2Contracts.del(null, chain);
+    ContractStore.poseidonMerkleAccumulatorV3Contracts.del(null, chain);
+    ContractStore.poseidonMerkleVerifierV3Contracts.del(null, chain);
+    ContractStore.tokenVaultV3Contracts.del(null, chain);
 
     ACTIVE_TXID_VERSIONS.forEach((txidVersion) => {
       if (!getChainSupportsV3(chain) && txidVersion === TXIDVersion.V3_PoseidonMerkle) {
@@ -2040,13 +2038,9 @@ class RailgunEngine extends EventEmitter {
   async unload() {
     // Unload chains
     await Promise.all(
-      ContractStore.railgunSmartWalletContracts.map(async (contractsForChainType, chainType) => {
-        await Promise.all(
-          contractsForChainType.map(async (_railgunSmartWalletContract, chainID) => {
-            EngineDebug.log(`unload network ${chainType}:${chainID}`);
-            await this.unloadNetwork({ type: chainType, id: chainID });
-          }),
-        );
+      ContractStore.railgunSmartWalletContracts.map(async (contract, txidVersion, chain) => {
+        EngineDebug.log(`unload network ${chain.type}:${chain.id}`);
+        await this.unloadNetwork(chain);
       }),
     );
 
@@ -2073,12 +2067,16 @@ class RailgunEngine extends EventEmitter {
       // Load UTXO and TXID merkletrees for wallet
       // eslint-disable-next-line no-await-in-loop
       await Promise.all(
-        this.utxoMerkletrees.map(txidVersion, async (utxoMerkletree) => {
-          await wallet.loadUTXOMerkletree(txidVersion, utxoMerkletree);
+        this.utxoMerkletrees.map(async (utxoMerkletree, thisTxidVersion) => {
+          if (thisTxidVersion === txidVersion) {
+            await wallet.loadUTXOMerkletree(txidVersion, utxoMerkletree);
+          }
         }),
       );
-      this.txidMerkletrees.forEach(txidVersion, (txidMerkletree) => {
-        wallet.loadRailgunTXIDMerkletree(txidVersion, txidMerkletree);
+      this.txidMerkletrees.forEach((txidMerkletree, thisTxidVersion) => {
+        if (thisTxidVersion === txidVersion) {
+          wallet.loadRailgunTXIDMerkletree(txidVersion, txidMerkletree);
+        }
       });
     }
   }

--- a/src/test/helper.test.ts
+++ b/src/test/helper.test.ts
@@ -152,9 +152,9 @@ const awaitPoseidonMerkleAccumulatorV3Update = async (txidVersion: TXIDVersion, 
   return awaitRailgunSmartWalletEvent(
     txidVersion,
     chain,
-    ContractStore.getPoseidonMerkleAccumulatorV3Contract(
-      chain,
-    ).contract.filters.AccumulatorStateUpdate(),
+    ContractStore.poseidonMerkleAccumulatorV3Contracts
+      .getOrThrow(null, chain)
+      .contract.filters.AccumulatorStateUpdate(),
   );
 };
 
@@ -164,7 +164,7 @@ export const awaitRailgunSmartWalletShield = async (txidVersion: TXIDVersion, ch
       return awaitRailgunSmartWalletEvent(
         txidVersion,
         chain,
-        ContractStore.getRailgunSmartWalletContract(chain).contract.filters.Shield(),
+        ContractStore.railgunSmartWalletContracts.getOrThrow(null, chain).contract.filters.Shield(),
       );
 
     case TXIDVersion.V3_PoseidonMerkle:
@@ -179,7 +179,9 @@ export const awaitRailgunSmartWalletTransact = async (txidVersion: TXIDVersion, 
       return awaitRailgunSmartWalletEvent(
         txidVersion,
         chain,
-        ContractStore.getRailgunSmartWalletContract(chain).contract.filters.Transact(),
+        ContractStore.railgunSmartWalletContracts
+          .getOrThrow(null, chain)
+          .contract.filters.Transact(),
       );
 
     case TXIDVersion.V3_PoseidonMerkle:
@@ -194,7 +196,9 @@ export const awaitRailgunSmartWalletUnshield = async (txidVersion: TXIDVersion, 
       return awaitRailgunSmartWalletEvent(
         txidVersion,
         chain,
-        ContractStore.getRailgunSmartWalletContract(chain).contract.filters.Unshield(),
+        ContractStore.railgunSmartWalletContracts
+          .getOrThrow(null, chain)
+          .contract.filters.Unshield(),
       );
 
     case TXIDVersion.V3_PoseidonMerkle:
@@ -209,7 +213,9 @@ export const awaitRailgunSmartWalletNullified = async (txidVersion: TXIDVersion,
       return awaitRailgunSmartWalletEvent(
         txidVersion,
         chain,
-        ContractStore.getRailgunSmartWalletContract(chain).contract.filters.Nullified(),
+        ContractStore.railgunSmartWalletContracts
+          .getOrThrow(null, chain)
+          .contract.filters.Nullified(),
       );
 
     case TXIDVersion.V3_PoseidonMerkle:

--- a/src/transaction/__tests__/transaction-erc20.test.ts
+++ b/src/transaction/__tests__/transaction-erc20.test.ts
@@ -124,14 +124,16 @@ describe('transaction-erc20', function test() {
     POI.setLaunchBlock(chain, 0);
 
     // Load fake contract
-    ContractStore.railgunSmartWalletContracts[chain.type] = [];
-    ContractStore.railgunSmartWalletContracts[chain.type][chain.id] =
+    ContractStore.railgunSmartWalletContracts.set(
+      null,
+      chain,
       new RailgunSmartWalletContract(
         config.contracts.proxy,
         new PollingJsonRpcProvider('abc', 1, 500),
         new PollingJsonRpcProvider('abc', 1, 500),
         chain,
-      );
+      ),
+    );
 
     tokenDataGetter = new TokenDataGetter(db);
 

--- a/src/transaction/__tests__/transaction-erc20.test.ts
+++ b/src/transaction/__tests__/transaction-erc20.test.ts
@@ -121,7 +121,7 @@ describe('transaction-erc20', function test() {
 
     await wallet.loadUTXOMerkletree(txidVersion, utxoMerkletree);
 
-    POI.setLaunchBlock(chain, 0);
+    POI.launchBlocks.set(null, chain, 0);
 
     // Load fake contract
     ContractStore.railgunSmartWalletContracts.set(

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -1,0 +1,53 @@
+import { Chain, TXIDVersion } from '../models';
+import { isDefined } from './is-defined';
+
+const ANY_TXID_VERSION = 'any';
+
+/**
+ * A simple nested datastructure that holds information per-chain and per
+ * RailgunTXIDVersion.
+ */
+export class Registry<T> {
+  private data: { [txidVersion: string]: T[][] };
+
+  constructor() {
+    this.data = {};
+  }
+
+  set(txidVersion: TXIDVersion | null, chain: Chain, value: T) {
+    this.data[txidVersion ?? ANY_TXID_VERSION] ??= [];
+    this.data[txidVersion ?? ANY_TXID_VERSION][chain.type] ??= [];
+    this.data[txidVersion ?? ANY_TXID_VERSION][chain.type][chain.id] = value;
+  }
+
+  has(txidVersion: TXIDVersion | null, chain: Chain): boolean {
+    return isDefined(this.get(txidVersion, chain));
+  }
+
+  get(txidVersion: TXIDVersion | null, chain: Chain): Optional<T> {
+    return this.data[txidVersion ?? ANY_TXID_VERSION]?.[chain.type]?.[chain.id];
+  }
+
+  del(txidVersion: TXIDVersion | null, chain: Chain) {
+    delete this.data[txidVersion ?? ANY_TXID_VERSION]?.[chain.type]?.[chain.id];
+  }
+
+  forEach(txidVersion: TXIDVersion | null, callback: (value: T) => void) {
+    const perChainType = this.data[txidVersion ?? ANY_TXID_VERSION] ?? [];
+    perChainType.forEach((perChainID) => {
+      perChainID.forEach((value) => {
+        if (isDefined(value)) {
+          callback(value);
+        }
+      });
+    });
+  }
+
+  map<R>(txidVersion: TXIDVersion | null, callback: (value: T) => R): R[] {
+    const result: R[] = [];
+    this.forEach(txidVersion, (value) => {
+      result.push(callback(value));
+    });
+    return result;
+  }
+}

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -1,5 +1,5 @@
-// eslint-disable-next-line import/no-cycle
-import { Chain, TXIDVersion } from '../models'; // This import cycle is just types
+import { Chain } from '../models/engine-types';
+import { TXIDVersion } from '../models/poi-types';
 import { isDefined } from './is-defined';
 
 const ANY_TXID_VERSION = 'any';

--- a/src/wallet/abstract-wallet.ts
+++ b/src/wallet/abstract-wallet.ts
@@ -198,6 +198,8 @@ abstract class AbstractWallet extends EventEmitter {
 
   private readonly decryptBalancesKeyForChain: Registry<Optional<string>> = new Registry();
 
+  // Not a `Registry` because these come from the database as nested arrays and
+  // we don't want to take risks associated with migrating the data format.
   private creationBlockNumbers: Optional<number[][]>;
 
   private generatingPOIsForChain: Registry<boolean> = new Registry();
@@ -3134,7 +3136,10 @@ abstract class AbstractWallet extends EventEmitter {
     return undefined;
   }
 
-  setCreationBlockNumbers(creationBlockNumbers: Optional<number[][]>): void {
+  /**
+   * @warning This method is ONLY intended for testing purposes.
+   */
+  testSpecificSetCreationBlockNumbers(creationBlockNumbers: Optional<number[][]>): void {
     this.creationBlockNumbers = creationBlockNumbers;
   }
 

--- a/src/wallet/abstract-wallet.ts
+++ b/src/wallet/abstract-wallet.ts
@@ -2826,7 +2826,7 @@ abstract class AbstractWallet extends EventEmitter {
       // Set a simple key for this run of decryptBalances, so we can return early if it changes
       // This will change if another decryptBalances is called for this chain, and we don't need multiple running at once
       const decryptingBalancesKey = generateSimpleKey();
-      this.decryptBalancesKeyForChain.set(null, chain, decryptingBalancesKey)
+      this.decryptBalancesKeyForChain.set(null, chain, decryptingBalancesKey);
 
       const utxoMerkletree = this.getUTXOMerkletree(txidVersion, chain);
 
@@ -3155,9 +3155,9 @@ abstract class AbstractWallet extends EventEmitter {
 
     // Clear wallet namespace, including decrypted TXOs and all details
     const namespace = this.getWalletDBPrefix(chain);
-    this.isClearingBalances.set(null, chain, true)
+    this.isClearingBalances.set(null, chain, true);
     await this.db.clearNamespace(namespace);
-    this.isClearingBalances.set(null, chain, false)
+    this.isClearingBalances.set(null, chain, false);
 
     Object.values(TXIDVersion).forEach((txidVersion) => {
       if (walletDetailsMap[txidVersion]) {

--- a/src/wallet/abstract-wallet.ts
+++ b/src/wallet/abstract-wallet.ts
@@ -1606,7 +1606,7 @@ abstract class AbstractWallet extends EventEmitter {
           );
           const { railgunTransaction } = txidMerkletreeData;
 
-          const poiLaunchBlock = POI.getLaunchBlock(txidMerkletree.chain);
+          const poiLaunchBlock = POI.launchBlocks.get(null, txidMerkletree.chain);
           if (!isDefined(poiLaunchBlock)) {
             throw new Error('No POI launch block for railgun txids');
           }

--- a/src/wallet/abstract-wallet.ts
+++ b/src/wallet/abstract-wallet.ts
@@ -200,9 +200,6 @@ abstract class AbstractWallet extends EventEmitter {
 
   private creationBlockNumbers: Optional<number[][]>;
 
-  // [type: [id: CachedStoredReceiveCommitment[]]]
-  private: CachedStoredReceiveCommitment[][][] = [];
-
   private generatingPOIsForChain: Registry<boolean> = new Registry();
 
   private receiveCommitmentsCache: Registry<Optional<TXO[]>> = new Registry();


### PR DESCRIPTION
## Context

1. Trying to simplify the codebase where repetitive patterns are used.
2. Looking for RAM optimizations

## Problem

Same problem as described in #80 

## Solution

Instead of replacing all nested sparse arrays with nested objects, I first created a `Registry` class which encapsulates the nested sparse array pattern, and made sure all tests pass.

Then, I merely changed the datastructure internally in `Registry` to be 3 `Map`s, and all tests still passed.

An exception is made for `creationBlockNumbers`, we left that data structure unchanged because it's stored in the database and we want to avoid unnecessary headaches with migrating the format in the database.

## Tests

- Unit tests pass
- Integration tests pass
- Tested end-to-end in a wallet in production (one unshield done)
- RAM profiling seems to indicate that nothing changed (not better, not worse)