### PR TITLE
Refactor: convert 14 public APIs to private

### DIFF
--- a/src/__tests__/railgun-engine.test.ts
+++ b/src/__tests__/railgun-engine.test.ts
@@ -209,8 +209,8 @@ describe('railgun-engine', function test() {
           };
           utxoBatchStartPosition += transaction.commitments.length;
 
-          // eslint-disable-next-line no-await-in-loop
-          await engine.handleNewRailgunTransactionsV2(
+          // eslint-disable-next-line no-await-in-loop, no-underscore-dangle
+          await engine._handleNewRailgunTransactionsV2(
             txidVersion,
             chain,
             [railgunTransaction],
@@ -1450,13 +1450,18 @@ describe('railgun-engine', function test() {
       type: ChainType.EVM,
       id: 10010,
     };
-    let lastSyncedBlock = await engine.getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line no-underscore-dangle
+    let lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(undefined);
-    await engine.setLastSyncedBlock(txidVersion, chainForSyncedBlock, 100);
-    lastSyncedBlock = await engine.getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line no-underscore-dangle
+    await engine._setLastSyncedBlock(txidVersion, chainForSyncedBlock, 100);
+    // eslint-disable-next-line no-underscore-dangle
+    lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100);
-    await engine.setLastSyncedBlock(txidVersion, chainForSyncedBlock, 100000);
-    lastSyncedBlock = await engine.getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line no-underscore-dangle
+    await engine._setLastSyncedBlock(txidVersion, chainForSyncedBlock, 100000);
+    // eslint-disable-next-line no-underscore-dangle
+    lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100000);
   });
 
@@ -1465,13 +1470,18 @@ describe('railgun-engine', function test() {
       type: ChainType.EVM,
       id: 10010,
     };
-    let lastSyncedBlock = await engine.getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line no-underscore-dangle
+    let lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(undefined);
-    await engine.setUTXOMerkletreeHistoryVersion(chainForSyncedBlock, 100);
-    lastSyncedBlock = await engine.getUTXOMerkletreeHistoryVersion(chainForSyncedBlock);
+    // eslint-disable-next-line no-underscore-dangle
+    await engine._setUTXOMerkletreeHistoryVersion(chainForSyncedBlock, 100);
+    // eslint-disable-next-line no-underscore-dangle
+    lastSyncedBlock = await engine._getUTXOMerkletreeHistoryVersion(chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100);
-    await engine.setUTXOMerkletreeHistoryVersion(chainForSyncedBlock, 100000);
-    lastSyncedBlock = await engine.getUTXOMerkletreeHistoryVersion(chainForSyncedBlock);
+    // eslint-disable-next-line no-underscore-dangle
+    await engine._setUTXOMerkletreeHistoryVersion(chainForSyncedBlock, 100000);
+    // eslint-disable-next-line no-underscore-dangle
+    lastSyncedBlock = await engine._getUTXOMerkletreeHistoryVersion(chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100000);
   });
 
@@ -1480,13 +1490,18 @@ describe('railgun-engine', function test() {
       type: ChainType.EVM,
       id: 10010,
     };
-    let lastSyncedBlock = await engine.getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line no-underscore-dangle
+    let lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(undefined);
-    await engine.setTxidV2MerkletreeHistoryVersion(chainForSyncedBlock, 100);
-    lastSyncedBlock = await engine.getTxidV2MerkletreeHistoryVersion(chainForSyncedBlock);
+    // eslint-disable-next-line no-underscore-dangle
+    await engine._setTxidV2MerkletreeHistoryVersion(chainForSyncedBlock, 100);
+    // eslint-disable-next-line no-underscore-dangle
+    lastSyncedBlock = await engine._getTxidV2MerkletreeHistoryVersion(chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100);
-    await engine.setTxidV2MerkletreeHistoryVersion(chainForSyncedBlock, 100000);
-    lastSyncedBlock = await engine.getTxidV2MerkletreeHistoryVersion(chainForSyncedBlock);
+    // eslint-disable-next-line no-underscore-dangle
+    await engine._setTxidV2MerkletreeHistoryVersion(chainForSyncedBlock, 100000);
+    // eslint-disable-next-line no-underscore-dangle
+    lastSyncedBlock = await engine._getTxidV2MerkletreeHistoryVersion(chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100000);
   });
 

--- a/src/__tests__/railgun-engine.test.ts
+++ b/src/__tests__/railgun-engine.test.ts
@@ -209,8 +209,8 @@ describe('railgun-engine', function test() {
           };
           utxoBatchStartPosition += transaction.commitments.length;
 
-          // eslint-disable-next-line no-await-in-loop, no-underscore-dangle
-          await engine._handleNewRailgunTransactionsV2(
+          // eslint-disable-next-line no-await-in-loop, dot-notation
+          await engine['handleNewRailgunTransactionsV2'](
             txidVersion,
             chain,
             [railgunTransaction],
@@ -1450,18 +1450,18 @@ describe('railgun-engine', function test() {
       type: ChainType.EVM,
       id: 10010,
     };
-    // eslint-disable-next-line no-underscore-dangle
-    let lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line dot-notation
+    let lastSyncedBlock = await engine['getLastSyncedBlock'](txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(undefined);
-    // eslint-disable-next-line no-underscore-dangle
-    await engine._setLastSyncedBlock(txidVersion, chainForSyncedBlock, 100);
-    // eslint-disable-next-line no-underscore-dangle
-    lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line dot-notation
+    await engine['setLastSyncedBlock'](txidVersion, chainForSyncedBlock, 100);
+    // eslint-disable-next-line dot-notation
+    lastSyncedBlock = await engine['getLastSyncedBlock'](txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100);
-    // eslint-disable-next-line no-underscore-dangle
-    await engine._setLastSyncedBlock(txidVersion, chainForSyncedBlock, 100000);
-    // eslint-disable-next-line no-underscore-dangle
-    lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line dot-notation
+    await engine['setLastSyncedBlock'](txidVersion, chainForSyncedBlock, 100000);
+    // eslint-disable-next-line dot-notation
+    lastSyncedBlock = await engine['getLastSyncedBlock'](txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100000);
   });
 
@@ -1470,18 +1470,18 @@ describe('railgun-engine', function test() {
       type: ChainType.EVM,
       id: 10010,
     };
-    // eslint-disable-next-line no-underscore-dangle
-    let lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line dot-notation
+    let lastSyncedBlock = await engine['getLastSyncedBlock'](txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(undefined);
-    // eslint-disable-next-line no-underscore-dangle
-    await engine._setUTXOMerkletreeHistoryVersion(chainForSyncedBlock, 100);
-    // eslint-disable-next-line no-underscore-dangle
-    lastSyncedBlock = await engine._getUTXOMerkletreeHistoryVersion(chainForSyncedBlock);
+    // eslint-disable-next-line dot-notation
+    await engine['setUTXOMerkletreeHistoryVersion'](chainForSyncedBlock, 100);
+    // eslint-disable-next-line dot-notation
+    lastSyncedBlock = await engine['getUTXOMerkletreeHistoryVersion'](chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100);
-    // eslint-disable-next-line no-underscore-dangle
-    await engine._setUTXOMerkletreeHistoryVersion(chainForSyncedBlock, 100000);
-    // eslint-disable-next-line no-underscore-dangle
-    lastSyncedBlock = await engine._getUTXOMerkletreeHistoryVersion(chainForSyncedBlock);
+    // eslint-disable-next-line dot-notation
+    await engine['setUTXOMerkletreeHistoryVersion'](chainForSyncedBlock, 100000);
+    // eslint-disable-next-line dot-notation
+    lastSyncedBlock = await engine['getUTXOMerkletreeHistoryVersion'](chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100000);
   });
 
@@ -1490,18 +1490,18 @@ describe('railgun-engine', function test() {
       type: ChainType.EVM,
       id: 10010,
     };
-    // eslint-disable-next-line no-underscore-dangle
-    let lastSyncedBlock = await engine._getLastSyncedBlock(txidVersion, chainForSyncedBlock);
+    // eslint-disable-next-line dot-notation
+    let lastSyncedBlock = await engine['getLastSyncedBlock'](txidVersion, chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(undefined);
-    // eslint-disable-next-line no-underscore-dangle
-    await engine._setTxidV2MerkletreeHistoryVersion(chainForSyncedBlock, 100);
-    // eslint-disable-next-line no-underscore-dangle
-    lastSyncedBlock = await engine._getTxidV2MerkletreeHistoryVersion(chainForSyncedBlock);
+    // eslint-disable-next-line dot-notation
+    await engine['setTxidV2MerkletreeHistoryVersion'](chainForSyncedBlock, 100);
+    // eslint-disable-next-line dot-notation
+    lastSyncedBlock = await engine['getTxidV2MerkletreeHistoryVersion'](chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100);
-    // eslint-disable-next-line no-underscore-dangle
-    await engine._setTxidV2MerkletreeHistoryVersion(chainForSyncedBlock, 100000);
-    // eslint-disable-next-line no-underscore-dangle
-    lastSyncedBlock = await engine._getTxidV2MerkletreeHistoryVersion(chainForSyncedBlock);
+    // eslint-disable-next-line dot-notation
+    await engine['setTxidV2MerkletreeHistoryVersion'](chainForSyncedBlock, 100000);
+    // eslint-disable-next-line dot-notation
+    lastSyncedBlock = await engine['getTxidV2MerkletreeHistoryVersion'](chainForSyncedBlock);
     expect(lastSyncedBlock).to.equal(100000);
   });
 

--- a/src/contracts/railgun-smart-wallet/V2/__tests__/railgun-smart-wallet.test.ts
+++ b/src/contracts/railgun-smart-wallet/V2/__tests__/railgun-smart-wallet.test.ts
@@ -39,11 +39,8 @@ import {
 import {
   CommitmentEvent,
   EngineEvent,
-  MerkletreeHistoryScanEventData,
-  MerkletreeScanStatus,
   UTXOScanDecryptBalancesCompleteEventData,
   UnshieldStoredEvent,
-  WalletScannedEventData,
 } from '../../../../models/event-types';
 import { Memo } from '../../../../note/memo';
 import { ViewOnlyWallet } from '../../../../wallet/view-only-wallet';
@@ -576,8 +573,8 @@ describe('railgun-smart-wallet', function runTests() {
       chain,
       startingBlock,
       latestBlock,
-      // eslint-disable-next-line no-underscore-dangle
-      () => engine._getNextStartingBlockSlowScan(txidVersion, chain),
+      // eslint-disable-next-line dot-notation
+      () => engine['getNextStartingBlockSlowScan'](txidVersion, chain),
       eventsListener,
       nullifiersListener,
       unshieldListener,
@@ -733,8 +730,8 @@ describe('railgun-smart-wallet', function runTests() {
       chain,
       startingBlock,
       latestBlock,
-      // eslint-disable-next-line no-underscore-dangle
-      () => engine._getNextStartingBlockSlowScan(txidVersion, chain),
+      // eslint-disable-next-line dot-notation
+      () => engine['getNextStartingBlockSlowScan'](txidVersion, chain),
       eventsListener,
       nullifiersListener,
       unshieldListener,
@@ -948,14 +945,14 @@ describe('railgun-smart-wallet', function runTests() {
       undefined, // walletIdFilter
     );
     expect(historyScanCompletedForChain).to.equal(chain);
-    // eslint-disable-next-line no-underscore-dangle
-    expect(await engine._getStartScanningBlock(txidVersion, chain)).to.be.above(0);
+    // eslint-disable-next-line dot-notation
+    expect(await engine['getStartScanningBlock'](txidVersion, chain)).to.be.above(0);
 
-    // eslint-disable-next-line no-underscore-dangle
-    await engine._clearSyncedUTXOMerkletreeLeavesAllTXIDVersions(chain);
+    // eslint-disable-next-line dot-notation
+    await engine['clearSyncedUTXOMerkletreeLeavesAllTXIDVersions'](chain);
     expect(await utxoMerkletree.getTreeLength(tree)).to.equal(0);
-    // eslint-disable-next-line no-underscore-dangle
-    expect(await engine._getStartScanningBlock(txidVersion, chain)).to.equal(0);
+    // eslint-disable-next-line dot-notation
+    expect(await engine['getStartScanningBlock'](txidVersion, chain)).to.equal(0);
 
     const forceRefresh = true;
     await wallet.refreshPOIsForAllTXIDVersions(chain, forceRefresh);

--- a/src/contracts/railgun-smart-wallet/V2/__tests__/railgun-smart-wallet.test.ts
+++ b/src/contracts/railgun-smart-wallet/V2/__tests__/railgun-smart-wallet.test.ts
@@ -576,7 +576,8 @@ describe('railgun-smart-wallet', function runTests() {
       chain,
       startingBlock,
       latestBlock,
-      () => engine.getNextStartingBlockSlowScan(txidVersion, chain),
+      // eslint-disable-next-line no-underscore-dangle
+      () => engine._getNextStartingBlockSlowScan(txidVersion, chain),
       eventsListener,
       nullifiersListener,
       unshieldListener,
@@ -732,7 +733,8 @@ describe('railgun-smart-wallet', function runTests() {
       chain,
       startingBlock,
       latestBlock,
-      () => engine.getNextStartingBlockSlowScan(txidVersion, chain),
+      // eslint-disable-next-line no-underscore-dangle
+      () => engine._getNextStartingBlockSlowScan(txidVersion, chain),
       eventsListener,
       nullifiersListener,
       unshieldListener,
@@ -946,11 +948,14 @@ describe('railgun-smart-wallet', function runTests() {
       undefined, // walletIdFilter
     );
     expect(historyScanCompletedForChain).to.equal(chain);
-    expect(await engine.getStartScanningBlock(txidVersion, chain)).to.be.above(0);
+    // eslint-disable-next-line no-underscore-dangle
+    expect(await engine._getStartScanningBlock(txidVersion, chain)).to.be.above(0);
 
-    await engine.clearSyncedUTXOMerkletreeLeavesAllTXIDVersions(chain);
+    // eslint-disable-next-line no-underscore-dangle
+    await engine._clearSyncedUTXOMerkletreeLeavesAllTXIDVersions(chain);
     expect(await utxoMerkletree.getTreeLength(tree)).to.equal(0);
-    expect(await engine.getStartScanningBlock(txidVersion, chain)).to.equal(0);
+    // eslint-disable-next-line no-underscore-dangle
+    expect(await engine._getStartScanningBlock(txidVersion, chain)).to.equal(0);
 
     const forceRefresh = true;
     await wallet.refreshPOIsForAllTXIDVersions(chain, forceRefresh);

--- a/src/railgun-engine.ts
+++ b/src/railgun-engine.ts
@@ -1978,7 +1978,7 @@ class RailgunEngine extends EventEmitter {
       : undefined;
   }
 
-  async decryptBalancesAllWallets(
+  private async decryptBalancesAllWallets(
     txidVersion: TXIDVersion,
     chain: Chain,
     walletIdFilter: Optional<string[]>,


### PR DESCRIPTION
## Context

Trying to simplify this codebase.

## Problem

RailgunEngine exposes some ~70 methods, and that's too much. Many of these methods are actually not used outside `engine`.

## Solution

Convert `public` methods to `private`.

~~There are some cases where the method is used only in tests, so it technically has to be `public`. In these cases, I named the method with an `_` prefix to signal to public API users that this is not *meant* to be used.~~ Nevermind, I found a way to use private methods in tests.

NOTE: `decryptBalancesAllWallets()` is now private, and `railgun-community/wallet` [wraps it as decryptBalances](https://github.com/Railgun-Community/wallet/blob/6e2a409bf80ee540dc6df4f4adc1a1f0ab72d918/src/services/railgun/wallets/balances.ts#L50), but this is a dead method that no one uses, so we can also delete that method from wallet too.
