### PR TITLE
more specific log for skipping getLatestValidatedTxidIndex so it does…

### DIFF
--- a/src/railgun-engine.ts
+++ b/src/railgun-engine.ts
@@ -995,10 +995,15 @@ class RailgunEngine extends EventEmitter {
     endScanPercentage: number,
   ) {
     const latestValidatedTxidIndex = await this.getLatestValidatedTxidIndex(txidVersion, chain);
+    // Log chain.id, txidVersion, and if not a POI node, the latest validated txid index.
     EngineDebug.log(
       `syncing railgun transactions to validated index (Chain: ${
         chain.id
-      }. txidVersion: ${txidVersion}): ${latestValidatedTxidIndex ?? 'NOT FOUND'}`,
+      }. txidVersion: ${txidVersion}): ${
+        this.isPOINode
+          ? 'POI Node: getLatestValidatedTxidIndex() skipped'
+          : latestValidatedTxidIndex ?? 'NOT FOUND'
+      }`,
     );
 
     const shouldAddNewRailgunTransactions = await this.shouldAddNewRailgunTransactions(
@@ -1152,8 +1157,8 @@ class RailgunEngine extends EventEmitter {
       }
 
       if (missingAnyCommitments) {
-        EngineDebug.log(
-          `Stopping queue of Railgun TXIDs - missing a commitment or unshield. This will occur whenever the TXIDs are further than the UTXOs data source.`,
+        EngineDebug.error(new Error(
+          `Stopping queue of Railgun TXIDs - missing a commitment or unshield. This will occur whenever the TXIDs are further than the UTXOs data source.`)
         );
         break;
       }


### PR DESCRIPTION
…n't look like an error in ppoi debug logs

change missingAnyCommitments log to an error so ppoi can pick it up and run refreshBalances in wallet if this specific error occurs; is required to run when ppoi node runs new and does not have the db's synced locally yet