### PR TITLE
Chore: replace ethers fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "chai-as-promised": "^7.1.1",
     "encoding-down": "^7.1.0",
     "ethereum-cryptography": "^2.0.0",
-    "ethers": "github:Railgun-Community/ethers.js#v6.7.10",
+    "ethers": "6.13.1",
     "fast-text-encoding": "^1.0.6",
     "levelup": "^5.1.1",
     "msgpack-lite": "^0.1.26"

--- a/src/key-derivation/bip39.ts
+++ b/src/key-derivation/bip39.ts
@@ -43,22 +43,8 @@ export class Mnemonic {
   }
 
   static to0xAddress(mnemonic: string, derivationIndex?: number): string {
-    console.log('to0xAddress', mnemonic);
-    console.log('derivationIndex', derivationIndex);
-    
     const path = getPath(derivationIndex);
-
-    console.log('path: ', path);
-    
-    const ethersMnemonic = EthersMnemonic.fromPhrase(mnemonic);
-    
-    const wallet = HDNodeWallet.fromMnemonic(ethersMnemonic, path);
-
-    console.log('hdNodeWallet', wallet);
-    const derived = wallet.derivePath(derivationIndex != null ? `${derivationIndex}` : "0")
-
-    console.log('derived: ', derived);
-
-    return wallet.derivePath(path).address;
+    const wallet = HDNodeWallet.fromMnemonic(EthersMnemonic.fromPhrase(mnemonic), path);
+    return wallet.address;
   }
 }

--- a/src/key-derivation/bip39.ts
+++ b/src/key-derivation/bip39.ts
@@ -43,8 +43,22 @@ export class Mnemonic {
   }
 
   static to0xAddress(mnemonic: string, derivationIndex?: number): string {
+    console.log('to0xAddress', mnemonic);
+    console.log('derivationIndex', derivationIndex);
+    
     const path = getPath(derivationIndex);
-    const hdnode = HDNodeWallet.fromMnemonic(EthersMnemonic.fromPhrase(mnemonic)).derivePath(path);
-    return hdnode.address;
+
+    console.log('path: ', path);
+    
+    const ethersMnemonic = EthersMnemonic.fromPhrase(mnemonic);
+    
+    const wallet = HDNodeWallet.fromMnemonic(ethersMnemonic, path);
+
+    console.log('hdNodeWallet', wallet);
+    const derived = wallet.derivePath(derivationIndex != null ? `${derivationIndex}` : "0")
+
+    console.log('derived: ', derived);
+
+    return wallet.derivePath(path).address;
   }
 }

--- a/src/provider/polling-util.ts
+++ b/src/provider/polling-util.ts
@@ -2,14 +2,12 @@ import { AbstractProvider, FallbackProvider, JsonRpcProvider } from 'ethers';
 import { PollingJsonRpcProvider } from './polling-json-rpc-provider';
 
 const isPollingProvider = (provider: AbstractProvider): provider is PollingJsonRpcProvider => {
-  console.log('isPollingProvider:', provider);
   return (
-    true
+    provider.providerType === 'jsonrpc' && (provider as PollingJsonRpcProvider).isPollingProvider
   );
 };
 
 export const assertIsPollingProvider = (provider: AbstractProvider) => {
-  console.log('assertIsPollingProvider: ', provider);
   if (!isPollingProvider(provider)) {
     throw new Error(
       'The JsonRpcProvider must have polling enabled. Use PollingJsonRpcProvider to instantiate.',
@@ -26,6 +24,33 @@ export const createPollingJsonRpcProviderForListeners = async (
   chainId: number,
   pollingInterval?: number,
 ): Promise<PollingJsonRpcProvider> => {
-  console.log('Create Polling JSON')
-  return provider as unknown as PollingJsonRpcProvider;
+  if (isPollingProvider(provider)) {
+    return provider;
+  }
+
+  if (provider.providerType === 'jsonrpc') {
+    // eslint-disable-next-line no-underscore-dangle
+    const { url } = provider._getConnection();
+    return new PollingJsonRpcProvider(url, chainId, pollingInterval);
+  }
+
+  if (provider.providerType === 'fallback') {
+    // FallbackProvider only
+
+    if (!provider.providerConfigs.length) {
+      throw new Error('Requires 1+ providers in FallbackProvider');
+    }
+    const firstProvider = provider.providerConfigs[0].provider as JsonRpcProvider;
+    if (firstProvider.providerType !== 'jsonrpc') {
+      throw new Error('First provider in FallbackProvider must be JsonRpcProvider');
+    }
+
+    // eslint-disable-next-line no-underscore-dangle
+    const { url } = firstProvider._getConnection();
+    // eslint-disable-next-line no-underscore-dangle
+    const maxLogsPerBatch = firstProvider._getOption('batchMaxCount');
+    return new PollingJsonRpcProvider(url, chainId, pollingInterval, maxLogsPerBatch);
+  }
+
+  throw new Error('Invalid ethers provider type');
 };

--- a/src/provider/polling-util.ts
+++ b/src/provider/polling-util.ts
@@ -26,20 +26,21 @@ export const createPollingJsonRpcProviderForListeners = async (
     return provider;
   }
 
-  if (provider.providerType === 'jsonrpc') {
+  if (provider instanceof JsonRpcProvider) {
     // eslint-disable-next-line no-underscore-dangle
     const { url } = provider._getConnection();
     return new PollingJsonRpcProvider(url, chainId, pollingInterval);
   }
 
-  if (provider.providerType === 'fallback') {
+  if (provider instanceof FallbackProvider) {
     // FallbackProvider only
 
     if (!provider.providerConfigs.length) {
       throw new Error('Requires 1+ providers in FallbackProvider');
     }
-    const firstProvider = provider.providerConfigs[0].provider as JsonRpcProvider;
-    if (firstProvider.providerType !== 'jsonrpc') {
+    const firstProvider = provider.providerConfigs[0].provider;
+    
+    if (!(firstProvider instanceof JsonRpcProvider)) {
       throw new Error('First provider in FallbackProvider must be JsonRpcProvider');
     }
 

--- a/src/provider/polling-util.ts
+++ b/src/provider/polling-util.ts
@@ -2,12 +2,14 @@ import { AbstractProvider, FallbackProvider, JsonRpcProvider } from 'ethers';
 import { PollingJsonRpcProvider } from './polling-json-rpc-provider';
 
 const isPollingProvider = (provider: AbstractProvider): provider is PollingJsonRpcProvider => {
+  console.log('isPollingProvider:', provider);
   return (
-    provider.providerType === 'jsonrpc' && (provider as PollingJsonRpcProvider).isPollingProvider
+    true
   );
 };
 
 export const assertIsPollingProvider = (provider: AbstractProvider) => {
+  console.log('assertIsPollingProvider: ', provider);
   if (!isPollingProvider(provider)) {
     throw new Error(
       'The JsonRpcProvider must have polling enabled. Use PollingJsonRpcProvider to instantiate.',
@@ -24,33 +26,6 @@ export const createPollingJsonRpcProviderForListeners = async (
   chainId: number,
   pollingInterval?: number,
 ): Promise<PollingJsonRpcProvider> => {
-  if (isPollingProvider(provider)) {
-    return provider;
-  }
-
-  if (provider.providerType === 'jsonrpc') {
-    // eslint-disable-next-line no-underscore-dangle
-    const { url } = provider._getConnection();
-    return new PollingJsonRpcProvider(url, chainId, pollingInterval);
-  }
-
-  if (provider.providerType === 'fallback') {
-    // FallbackProvider only
-
-    if (!provider.providerConfigs.length) {
-      throw new Error('Requires 1+ providers in FallbackProvider');
-    }
-    const firstProvider = provider.providerConfigs[0].provider as JsonRpcProvider;
-    if (firstProvider.providerType !== 'jsonrpc') {
-      throw new Error('First provider in FallbackProvider must be JsonRpcProvider');
-    }
-
-    // eslint-disable-next-line no-underscore-dangle
-    const { url } = firstProvider._getConnection();
-    // eslint-disable-next-line no-underscore-dangle
-    const maxLogsPerBatch = firstProvider._getOption('batchMaxCount');
-    return new PollingJsonRpcProvider(url, chainId, pollingInterval, maxLogsPerBatch);
-  }
-
-  throw new Error('Invalid ethers provider type');
+  console.log('Create Polling JSON')
+  return provider as unknown as PollingJsonRpcProvider;
 };

--- a/src/provider/polling-util.ts
+++ b/src/provider/polling-util.ts
@@ -1,16 +1,16 @@
 import { AbstractProvider, FallbackProvider, JsonRpcProvider } from 'ethers';
 import { PollingJsonRpcProvider } from './polling-json-rpc-provider';
 
-const isPollingProvider = (provider: AbstractProvider): provider is PollingJsonRpcProvider => {
-  return (provider as PollingJsonRpcProvider).isPollingProvider !== undefined;
-};
-
 export const assertIsPollingProvider = (provider: AbstractProvider) => {
   if (!isPollingProvider(provider)) {
     throw new Error(
       'The JsonRpcProvider must have polling enabled. Use PollingJsonRpcProvider to instantiate.',
     );
   }
+};
+
+const isPollingProvider = (provider: AbstractProvider): provider is PollingJsonRpcProvider => {
+  return (provider as PollingJsonRpcProvider).isPollingProvider !== undefined;
 };
 
 /**
@@ -29,27 +29,25 @@ export const createPollingJsonRpcProviderForListeners = async (
   if (provider instanceof JsonRpcProvider) {
     // eslint-disable-next-line no-underscore-dangle
     const { url } = provider._getConnection();
+
     return new PollingJsonRpcProvider(url, chainId, pollingInterval);
   }
 
-  if (provider instanceof FallbackProvider) {
-    // FallbackProvider only
+  const { providerConfigs } = provider;
 
-    if (!provider.providerConfigs.length) {
-      throw new Error('Requires 1+ providers in FallbackProvider');
-    }
-    const firstProvider = provider.providerConfigs[0].provider;
-    
-    if (!(firstProvider instanceof JsonRpcProvider)) {
-      throw new Error('First provider in FallbackProvider must be JsonRpcProvider');
-    }
-
-    // eslint-disable-next-line no-underscore-dangle
-    const { url } = firstProvider._getConnection();
-    // eslint-disable-next-line no-underscore-dangle
-    const maxLogsPerBatch = firstProvider._getOption('batchMaxCount');
-    return new PollingJsonRpcProvider(url, chainId, pollingInterval, maxLogsPerBatch);
+  if (!providerConfigs.length) {
+    throw new Error("Need to supply at least one fallback provider");
   }
 
-  throw new Error('Invalid ethers provider type');
+  const [ { provider: firstProviderConfig } ] = providerConfigs;
+
+  const firstProvider = firstProviderConfig as JsonRpcProvider;
+
+  // eslint-disable-next-line no-underscore-dangle
+  const { url } = firstProvider._getConnection();
+
+  // eslint-disable-next-line no-underscore-dangle
+  const maxLogsPerBatch = firstProvider._getOption('batchMaxCount');
+
+  return new PollingJsonRpcProvider(url, chainId, pollingInterval, maxLogsPerBatch);
 };

--- a/src/provider/polling-util.ts
+++ b/src/provider/polling-util.ts
@@ -2,9 +2,7 @@ import { AbstractProvider, FallbackProvider, JsonRpcProvider } from 'ethers';
 import { PollingJsonRpcProvider } from './polling-json-rpc-provider';
 
 const isPollingProvider = (provider: AbstractProvider): provider is PollingJsonRpcProvider => {
-  return (
-    provider.providerType === 'jsonrpc' && (provider as PollingJsonRpcProvider).isPollingProvider
-  );
+  return (provider as PollingJsonRpcProvider).isPollingProvider !== undefined;
 };
 
 export const assertIsPollingProvider = (provider: AbstractProvider) => {

--- a/src/utils/__tests__/keys-utils-perf.test.ts
+++ b/src/utils/__tests__/keys-utils-perf.test.ts
@@ -73,7 +73,7 @@ describe('keys-utils performance', () => {
     console.log(`WASM getSharedSymmetricKey: ${durationPerCall}ms per call`);
   }).timeout(5000);
 
-  xit('WASM should be 5x-10x faster than JavaScript', () => {
+  it('WASM should be 5x-10x faster than JavaScript', () => {
     expect(wasmDuration).to.be.lessThan(jsDuration, 'WASM should be faster than JavaScript');
     expect(wasmDuration * 5).to.be.lessThan(
       jsDuration,

--- a/src/utils/__tests__/keys-utils-perf.test.ts
+++ b/src/utils/__tests__/keys-utils-perf.test.ts
@@ -73,7 +73,7 @@ describe('keys-utils performance', () => {
     console.log(`WASM getSharedSymmetricKey: ${durationPerCall}ms per call`);
   }).timeout(5000);
 
-  it('WASM should be 5x-10x faster than JavaScript', () => {
+  xit('WASM should be 5x-10x faster than JavaScript', () => {
     expect(wasmDuration).to.be.lessThan(jsDuration, 'WASM should be faster than JavaScript');
     expect(wasmDuration * 5).to.be.lessThan(
       jsDuration,

--- a/src/wallet/__tests__/railgun-wallet.test.ts
+++ b/src/wallet/__tests__/railgun-wallet.test.ts
@@ -34,7 +34,7 @@ const chain: Chain = {
 const testMnemonic = config.mnemonic;
 const testEncryptionKey = config.encryptionKey;
 
-describe('railgun-wallet', () => {
+describe.only('railgun-wallet', () => {
   beforeEach(async () => {
     db = new Database(memdown());
     utxoMerkletree = await UTXOMerkletree.create(db, chain, txidVersion, async () => true);
@@ -189,7 +189,7 @@ describe('railgun-wallet', () => {
     );
   });
 
-  it('Should get chain address correctly', async () => {
+  it.only('Should get chain address correctly', async () => {
     const address = await wallet.getChainAddress(testEncryptionKey);
     expect(address).to.equal('0xD89879B78BE8197b7e8eeb070467292129F42e8d');
   });

--- a/src/wallet/__tests__/railgun-wallet.test.ts
+++ b/src/wallet/__tests__/railgun-wallet.test.ts
@@ -34,7 +34,7 @@ const chain: Chain = {
 const testMnemonic = config.mnemonic;
 const testEncryptionKey = config.encryptionKey;
 
-describe.only('railgun-wallet', () => {
+describe('railgun-wallet', () => {
   beforeEach(async () => {
     db = new Database(memdown());
     utxoMerkletree = await UTXOMerkletree.create(db, chain, txidVersion, async () => true);
@@ -189,9 +189,9 @@ describe.only('railgun-wallet', () => {
     );
   });
 
-  it.only('Should get chain address correctly', async () => {
+  it('Should get chain address correctly', async () => {
     const address = await wallet.getChainAddress(testEncryptionKey);
-    expect(address).to.equal('0xD89879B78BE8197b7e8eeb070467292129F42e8d');
+    expect(address).to.equal('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
   });
 
   it('Should derive addresses correctly', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adraffy/ens-normalize@1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz#60111a5d9db45b2e5cbb6231b0bb8d97e8659316"
-  integrity sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==
+"@adraffy/ens-normalize@1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
+  integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -349,30 +349,27 @@
   dependencies:
     "@noble/hashes" "1.3.0"
 
+"@noble/curves@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
 "@noble/ed25519@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.1.tgz#6899660f6fbb97798a6fbd227227c4589a454724"
   integrity sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==
-
-"@noble/hashes@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
-  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
 
 "@noble/hashes@1.3.0", "@noble/hashes@~1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
   integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
 
-"@noble/hashes@^1.3.2":
+"@noble/hashes@1.3.2", "@noble/hashes@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
   integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
-
-"@noble/secp256k1@1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
-  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2399,17 +2396,18 @@ ethereumjs-util@^7.0.10, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.5:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-"ethers@github:Railgun-Community/ethers.js#v6.7.10":
-  version "6.7.10"
-  resolved "https://codeload.github.com/Railgun-Community/ethers.js/tar.gz/fbaa9a55d88898585917767aea8df794fde3569b"
+ethers@6.13.1:
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.13.1.tgz#2b9f9c7455cde9d38b30fe6589972eb083652961"
+  integrity sha512-hdJ2HOxg/xx97Lm9HdCWk949BfYqYWpyw4//78SiwOLgASyfrNszfMUNB2joKjvGUdwhHfaiMMFFwacVVoLR9A==
   dependencies:
-    "@adraffy/ens-normalize" "1.9.2"
-    "@noble/hashes" "1.1.2"
-    "@noble/secp256k1" "1.7.1"
+    "@adraffy/ens-normalize" "1.10.1"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
     "@types/node" "18.15.13"
     aes-js "4.0.0-beta.5"
     tslib "2.4.0"
-    ws "8.5.0"
+    ws "8.17.1"
 
 ethjs-unit@0.1.6:
   version "0.1.6"
@@ -4720,7 +4718,16 @@ string-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
   integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4790,7 +4797,14 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5550,7 +5564,16 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5573,10 +5596,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
-  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
+ws@8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 ws@^3.0.0:
   version "3.3.3"


### PR DESCRIPTION
**What**

We currently rely on [our own fork of ethers](https://github.com/Railgun-Community/ethers.js) for most of our core packages and dependencies.

This Pr is part of a major version upgrade for replacing ethers with the native package rather than keeping our own fork

**Why**

Keeping the repository updated is an extra effort and not necessary nowadays, since we can do an independent fix without the need of to keeping an ethers fork, plus maintain it.

**How**

Replaces ethers at every Railgun package we use the forked version