### PR TITLE
chore: revert #109 && add isDefined log check

### DIFF
--- a/src/solutions/complex-solutions.ts
+++ b/src/solutions/complex-solutions.ts
@@ -13,6 +13,7 @@ import { ZERO_32_BYTE_VALUE } from '../utils/constants';
 const logTreeSortedBalancesMetadata = (treeSortedBalances: TreeBalance[]) => {
   EngineDebug.log('treeSortedBalances metadata:');
   for (const treeBalance of treeSortedBalances) {
+    if (!isDefined(treeBalance)) continue;
     EngineDebug.log(`Token: ${treeBalance.tokenData.tokenAddress}`);
     EngineDebug.log(`Total balance: ${treeBalance.balance.toString()}`);
     EngineDebug.log(

--- a/src/test/engine-stubs.test.ts
+++ b/src/test/engine-stubs.test.ts
@@ -71,11 +71,9 @@ export const createEngineWalletTreeBalancesStub = async (
     tokenAddress.replace('0x', ''),
     ByteLength.UINT_256,
   );
-  treeBalancesStub = sinon
-    .stub(RailgunWallet.prototype, 'getTotalBalancesGroupedByTreeNumber')
-    .resolves({
-      [formattedTokenAddress]: [await getMockBalanceData(addressData, tokenAddress, tree)],
-    });
+  treeBalancesStub = sinon.stub(RailgunWallet.prototype, 'getTotalBalancesByTreeNumber').resolves({
+    [formattedTokenAddress]: [await getMockBalanceData(addressData, tokenAddress, tree)],
+  });
 };
 
 export const createEngineVerifyProofStub = () => {

--- a/src/wallet/abstract-wallet.ts
+++ b/src/wallet/abstract-wallet.ts
@@ -2730,14 +2730,11 @@ abstract class AbstractWallet extends EventEmitter {
   }
 
   /**
-   * Get balances for all tokens, grouped by tree number.
-   *
-   * NOTE: For any tree where a token has no UTXO's, a zero-balance entry will be created.
-   *
+   * Sort token balances by tree
    * @param chain - chain type/id of token
    * @returns balances by tree
    */
-  async getTotalBalancesGroupedByTreeNumber(
+  async getTotalBalancesByTreeNumber(
     txidVersion: TXIDVersion,
     chain: Chain,
     balanceBucketFilter: WalletBalanceBucket[],
@@ -2755,31 +2752,26 @@ abstract class AbstractWallet extends EventEmitter {
     const totalBalancesByTreeNumber: TotalBalancesByTreeNumber = {};
 
     // Loop through each token
+
     for (const tokenHash of Object.keys(tokenBalances)) {
       // Create balances tree array
       totalBalancesByTreeNumber[tokenHash] = [];
 
-      // Find max tree number to know array size needed and avoid undefined entries
-      const maxTree = Math.max(...tokenBalances[tokenHash].utxos.map((utxo) => utxo.tree), 0);
-
-      // Initialize all tree positions with zero balances
-      for (let i = 0; i <= maxTree; i += 1) {
-        totalBalancesByTreeNumber[tokenHash][i] = {
-          balance: 0n,
-          utxos: [],
-          tokenData: tokenBalances[tokenHash].tokenData,
-        };
-      }
-
-      // Fill in actual balances where we have UTXOs
+      // Loop through each TXO and sort by tree
       for (const utxo of tokenBalances[tokenHash].utxos) {
-        const treeBalance = totalBalancesByTreeNumber[tokenHash][utxo.tree];
-        treeBalance.balance += utxo.note.value;
-        treeBalance.utxos.push(utxo);
+        if (!isDefined(totalBalancesByTreeNumber[tokenHash][utxo.tree])) {
+          totalBalancesByTreeNumber[tokenHash][utxo.tree] = {
+            balance: utxo.note.value,
+            utxos: [utxo],
+            tokenData: utxo.note.tokenData,
+          };
+        } else {
+          totalBalancesByTreeNumber[tokenHash][utxo.tree].balance += utxo.note.value;
+          totalBalancesByTreeNumber[tokenHash][utxo.tree].utxos.push(utxo);
+        }
       }
     }
 
-    // Return array of balances, where each array position is a tree number and balances
     return totalBalancesByTreeNumber;
   }
 
@@ -2790,15 +2782,12 @@ abstract class AbstractWallet extends EventEmitter {
     balanceBucketFilter: WalletBalanceBucket[],
     originShieldTxidForSpendabilityOverride?: string,
   ): Promise<TreeBalance[]> {
-    // Get an array of balances, where each array position is a tree number and balances
-    const totalBalancesByTreeNumber = await this.getTotalBalancesGroupedByTreeNumber(
+    const totalBalancesByTreeNumber = await this.getTotalBalancesByTreeNumber(
       txidVersion,
       chain,
       balanceBucketFilter,
       originShieldTxidForSpendabilityOverride,
     );
-
-    // Get balances of the specific token for all trees
     const treeSortedBalances = totalBalancesByTreeNumber[tokenHash] ?? [];
     return treeSortedBalances;
   }


### PR DESCRIPTION
Reverts #109 and adds a simple `isDefined` check before logging tree data 