### PR TITLE
feat: enhance RelayAdaptV2Contract and RelayAdaptVersionedSmartContract

### DIFF
--- a/src/contracts/relay-adapt/__tests__/relay-adapt.test.ts
+++ b/src/contracts/relay-adapt/__tests__/relay-adapt.test.ts
@@ -280,6 +280,12 @@ describe('relay-adapt', function test() {
     );
 
     const random = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd';
+    const shield = new ShieldNoteERC20(wallet.masterPublicKey, SHIELD_RANDOM, 10000n, WETH_TOKEN_ADDRESS);
+    const shieldPrivateKey = ByteUtils.hexToBytes(ByteUtils.randomHex(32));
+    const shieldRequest = await shield.serialize(
+      shieldPrivateKey,
+      wallet.getViewingKeyPair().pubkey,
+    );
 
     const relayTransactionGasEstimate =
       await RelayAdaptVersionedSmartContracts.populateUnshieldBaseToken(
@@ -288,6 +294,8 @@ describe('relay-adapt', function test() {
         dummyTransactions,
         ethersWallet.address,
         random,
+        true,
+        shieldRequest
       );
 
     relayTransactionGasEstimate.from = DEAD_ADDRESS;
@@ -323,7 +331,12 @@ describe('relay-adapt', function test() {
     transactionBatch.addOutput(broadcasterFee); // Simulate Broadcaster fee output.
 
     const unshieldValue = 300n;
-
+    const shield = new ShieldNoteERC20(wallet.masterPublicKey, SHIELD_RANDOM, 0n, WETH_TOKEN_ADDRESS);
+    const shieldPrivateKey = ByteUtils.hexToBytes(ByteUtils.randomHex(32));
+    const shieldRequest = await shield.serialize(
+      shieldPrivateKey,
+      wallet.getViewingKeyPair().pubkey,
+    );
     const unshieldNote = new UnshieldNoteERC20(
       RelayAdaptVersionedSmartContracts.getRelayAdaptContract(txidVersion, chain).address,
       unshieldValue,
@@ -348,6 +361,8 @@ describe('relay-adapt', function test() {
         dummyTransactions,
         ethersWallet.address,
         random,
+        true,
+        shieldRequest
       );
     expect(relayAdaptParams).to.equal(
       '0xa54346cdc981dd16bf95990bd28264a2e498e8db8be602b9611b999df51f3cf1',
@@ -384,6 +399,8 @@ describe('relay-adapt', function test() {
       provedTransactions,
       ethersWallet.address,
       random,
+      true,
+      shieldRequest
     );
 
     // 6: Send relay transaction.

--- a/src/contracts/relay-adapt/relay-adapt-versioned-smart-contracts.ts
+++ b/src/contracts/relay-adapt/relay-adapt-versioned-smart-contracts.ts
@@ -34,6 +34,8 @@ export class RelayAdaptVersionedSmartContracts {
     transactions: (TransactionStructV2 | TransactionStructV3)[],
     unshieldAddress: string,
     random31Bytes: string,
+    useDummyProof: boolean,
+    shieldRequest: ShieldRequestStruct,
   ): Promise<ContractTransaction> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
@@ -42,6 +44,8 @@ export class RelayAdaptVersionedSmartContracts {
           transactions as TransactionStructV2[],
           unshieldAddress,
           random31Bytes,
+          useDummyProof,
+          shieldRequest
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {
@@ -102,6 +106,8 @@ export class RelayAdaptVersionedSmartContracts {
     dummyUnshieldTransactions: (TransactionStructV2 | TransactionStructV3)[],
     unshieldAddress: string,
     random31Bytes: string,
+    sendWithPublicWallet: boolean,
+    shieldStruct: ShieldRequestStruct,
   ): Promise<string> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
@@ -110,6 +116,8 @@ export class RelayAdaptVersionedSmartContracts {
           dummyUnshieldTransactions as TransactionStructV2[],
           unshieldAddress,
           random31Bytes,
+          sendWithPublicWallet,
+          shieldStruct
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {


### PR DESCRIPTION
### Updates to `RelayAdaptV2Contract`:

* Added a `ShieldRequestStruct` parameter to methods like `getOrderedCallsForUnshieldBaseToken`, `getRelayAdaptParamsUnshieldBaseToken`, and `populateUnshieldBaseToken`. [[1]](diffhunk://#diff-9c7a8e8f880a8e0e6ad47bc5ca66c42946c497d7d2fbd5381e8608036f108c94R79) [[2]](diffhunk://#diff-9c7a8e8f880a8e0e6ad47bc5ca66c42946c497d7d2fbd5381e8608036f108c94R96-R115) [[3]](diffhunk://#diff-9c7a8e8f880a8e0e6ad47bc5ca66c42946c497d7d2fbd5381e8608036f108c94R128-R136)
* Introduced logic to re-wrap base tokens in case of transaction failures.
* Updated the `requireSuccess` flag to be dynamically set based on `useDummyProof` or `sendWithPublicWallet` parameters.

### Updates to `RelayAdaptVersionedSmartContracts`:

* Extended methods to accept `useDummyProof`, `sendWithPublicWallet`, and `ShieldRequestStruct` parameters. [[1]](diffhunk://#diff-55dac9d69fcb5ff53149ca0e0329568fc664a2f3b8ba9c9b4b93e4fa45850170R37-R38) [[2]](diffhunk://#diff-55dac9d69fcb5ff53149ca0e0329568fc664a2f3b8ba9c9b4b93e4fa45850170R47-R48) [[3]](diffhunk://#diff-55dac9d69fcb5ff53149ca0e0329568fc664a2f3b8ba9c9b4b93e4fa45850170R109-R110) [[4]](diffhunk://#diff-55dac9d69fcb5ff53149ca0e0329568fc664a2f3b8ba9c9b4b93e4fa45850170R119-R120)
