### PR TITLE
feat: enhance RelayAdaptV2Contract

### DIFF
--- a/src/contracts/railgun-smart-wallet/V2/__tests__/railgun-smart-wallet-events.test.ts
+++ b/src/contracts/railgun-smart-wallet/V2/__tests__/railgun-smart-wallet-events.test.ts
@@ -80,9 +80,9 @@ const testHistoricalEventsForRange = async (
       }
       foundNullifiers += nullifier.length;
     },
-    async () => {},
-    async () => {},
-    async () => {},
+    async () => { },
+    async () => { },
+    async () => { },
   );
   expect(foundShieldEvents).to.be.greaterThanOrEqual(1);
   expect(foundTransact).to.be.greaterThanOrEqual(1);
@@ -107,7 +107,7 @@ describe('railgun-smart-wallet-events', function runTests() {
 
     engine.prover.setSnarkJSGroth16(groth16 as SnarkJSGroth16);
 
-    provider = new PollingJsonRpcProvider('https://rpc.ankr.com/eth', 1, 100);
+    provider = new PollingJsonRpcProvider('https://eth.llamarpc.com', 1, 100);
 
     chain = {
       type: ChainType.EVM,

--- a/src/contracts/relay-adapt/V2/relay-adapt-v2.ts
+++ b/src/contracts/relay-adapt/V2/relay-adapt-v2.ts
@@ -99,12 +99,13 @@ export class RelayAdaptV2Contract {
     dummyTransactions: TransactionStructV2[],
     unshieldAddress: string,
     random: string,
+    sendWithPublicWallet: boolean,
   ): Promise<string> {
     const orderedCalls: ContractTransaction[] = await this.getOrderedCallsForUnshieldBaseToken(
       unshieldAddress,
     );
 
-    const requireSuccess = true;
+    const requireSuccess = sendWithPublicWallet;
     return RelayAdaptHelper.getRelayAdaptParams(
       dummyTransactions,
       random,
@@ -117,12 +118,13 @@ export class RelayAdaptV2Contract {
     transactions: TransactionStructV2[],
     unshieldAddress: string,
     random31Bytes: string,
+    useDummyProof: boolean,
   ): Promise<ContractTransaction> {
     const orderedCalls: ContractTransaction[] = await this.getOrderedCallsForUnshieldBaseToken(
       unshieldAddress,
     );
 
-    const requireSuccess = true;
+    const requireSuccess = useDummyProof;
     return this.populateRelay(transactions, random31Bytes, requireSuccess, orderedCalls, {});
   }
 

--- a/src/contracts/relay-adapt/__tests__/relay-adapt.test.ts
+++ b/src/contracts/relay-adapt/__tests__/relay-adapt.test.ts
@@ -288,6 +288,7 @@ describe('relay-adapt', function test() {
         dummyTransactions,
         ethersWallet.address,
         random,
+        true, // useDummyProof
       );
 
     relayTransactionGasEstimate.from = DEAD_ADDRESS;
@@ -348,6 +349,7 @@ describe('relay-adapt', function test() {
         dummyTransactions,
         ethersWallet.address,
         random,
+        true,
       );
     expect(relayAdaptParams).to.equal(
       '0xa54346cdc981dd16bf95990bd28264a2e498e8db8be602b9611b999df51f3cf1',
@@ -363,7 +365,7 @@ describe('relay-adapt', function test() {
       wallet,
       txidVersion,
       testEncryptionKey,
-      () => {},
+      () => { },
       false, // shouldGeneratePreTransactionPOIs
     );
     for (const transaction of provedTransactions) {
@@ -384,6 +386,7 @@ describe('relay-adapt', function test() {
       provedTransactions,
       ethersWallet.address,
       random,
+      true,
     );
 
     // 6: Send relay transaction.
@@ -553,7 +556,7 @@ describe('relay-adapt', function test() {
       wallet,
       txidVersion,
       testEncryptionKey,
-      () => {},
+      () => { },
       false, // shouldGeneratePreTransactionPOIs
     );
     for (const transaction of provedTransactions) {
@@ -636,7 +639,7 @@ describe('relay-adapt', function test() {
       wallet,
       txidVersion,
       testEncryptionKey,
-      () => {},
+      () => { },
       false, // shouldGeneratePreTransactionPOIs
     );
     const transact = await RailgunVersionedSmartContracts.generateTransact(
@@ -803,7 +806,7 @@ describe('relay-adapt', function test() {
       wallet,
       txidVersion,
       testEncryptionKey,
-      () => {},
+      () => { },
       false, // shouldGeneratePreTransactionPOIs
     );
     for (const transaction of provedTransactions) {
@@ -867,9 +870,9 @@ describe('relay-adapt', function test() {
 
     const expectedPrivateWethBalance = BigInt(
       9975 /* original shield */ -
-        300 /* broadcaster fee */ -
-        1000 /* unshield */ +
-        8 /* re-shield (1000 unshield amount - 2 unshield fee - 990 send amount - 0 re-shield fee) */,
+      300 /* broadcaster fee */ -
+      1000 /* unshield */ +
+      8 /* re-shield (1000 unshield amount - 2 unshield fee - 990 send amount - 0 re-shield fee) */,
     );
     const expectedTotalPrivateWethBalance = expectedPrivateWethBalance + 300n; // Add broadcaster fee.
 
@@ -990,7 +993,7 @@ describe('relay-adapt', function test() {
       wallet,
       txidVersion,
       testEncryptionKey,
-      () => {},
+      () => { },
       false, // shouldGeneratePreTransactionPOIs
     );
     for (const transaction of provedTransactions) {
@@ -1052,11 +1055,11 @@ describe('relay-adapt', function test() {
 
     const expectedPrivateWethBalance = BigInt(
       99750 /* original */ -
-        300 /* broadcaster fee */ -
-        10000 /* unshield amount */ -
-        0 /* failed cross contract send: no change */ +
-        9975 /* re-shield amount */ -
-        24 /* shield fee */,
+      300 /* broadcaster fee */ -
+      10000 /* unshield amount */ -
+      0 /* failed cross contract send: no change */ +
+      9975 /* re-shield amount */ -
+      24 /* shield fee */,
     );
     const expectedTotalPrivateWethBalance = expectedPrivateWethBalance + 300n; // Add broadcaster fee.
 
@@ -1177,7 +1180,7 @@ describe('relay-adapt', function test() {
       wallet,
       txidVersion,
       testEncryptionKey,
-      () => {},
+      () => { },
       false, // shouldGeneratePreTransactionPOIs
     );
     for (const transaction of provedTransactions) {

--- a/src/contracts/relay-adapt/relay-adapt-versioned-smart-contracts.ts
+++ b/src/contracts/relay-adapt/relay-adapt-versioned-smart-contracts.ts
@@ -34,6 +34,7 @@ export class RelayAdaptVersionedSmartContracts {
     transactions: (TransactionStructV2 | TransactionStructV3)[],
     unshieldAddress: string,
     random31Bytes: string,
+    useDummyProof: boolean,
   ): Promise<ContractTransaction> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
@@ -42,6 +43,7 @@ export class RelayAdaptVersionedSmartContracts {
           transactions as TransactionStructV2[],
           unshieldAddress,
           random31Bytes,
+          useDummyProof,
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {
@@ -102,6 +104,7 @@ export class RelayAdaptVersionedSmartContracts {
     dummyUnshieldTransactions: (TransactionStructV2 | TransactionStructV3)[],
     unshieldAddress: string,
     random31Bytes: string,
+    sendWithPublicWallet: boolean,
   ): Promise<string> {
     switch (txidVersion) {
       case TXIDVersion.V2_PoseidonMerkle: {
@@ -110,6 +113,7 @@ export class RelayAdaptVersionedSmartContracts {
           dummyUnshieldTransactions as TransactionStructV2[],
           unshieldAddress,
           random31Bytes,
+          sendWithPublicWallet,
         );
       }
       case TXIDVersion.V3_PoseidonMerkle: {

--- a/src/validation/__tests__/extract-transaction-data.test.ts
+++ b/src/validation/__tests__/extract-transaction-data.test.ts
@@ -51,7 +51,6 @@ const txidVersion = getTestTXIDVersion();
 
 const RANDOM_RELAY_ADAPT = ByteUtils.randomHex(31);
 const MOCK_TOKEN_ADDRESS = config.contracts.rail;
-
 const TREE = 0;
 let chain: Chain;
 let tokenDataGetter: TokenDataGetter;
@@ -303,6 +302,7 @@ describe('extract-transaction-data', () => {
       transactions,
       MOCK_ETH_WALLET_ADDRESS,
       RANDOM_RELAY_ADAPT,
+      false, // useDummyProof
     );
     const firstNoteERC20AmountMap = await extractFirstNoteERC20AmountMapFromTransactionRequest(
       txidVersion,
@@ -343,6 +343,7 @@ describe('extract-transaction-data', () => {
       transactions,
       MOCK_ETH_WALLET_ADDRESS,
       RANDOM_RELAY_ADAPT,
+      false, // useDummyProof
     );
     const firstNoteERC20AmountMap = await extractFirstNoteERC20AmountMapFromTransactionRequest(
       txidVersion,


### PR DESCRIPTION
This pull request introduces updates to enhance the functionality of the `relay-adapt` module, including the addition of new parameters to support conditional behavior, updates to test cases to reflect these changes, and a minor update to the provider URL in the `railgun-smart-wallet` module.

### Enhancements to `relay-adapt` functionality:

* [`src/contracts/relay-adapt/V2/relay-adapt-v2.ts`](diffhunk://#diff-9c7a8e8f880a8e0e6ad47bc5ca66c42946c497d7d2fbd5381e8608036f108c94R102-R108): Added `sendWithPublicWallet` and `useDummyProof` boolean parameters to methods for enabling conditional behavior when processing transactions. These parameters replace the hardcoded `requireSuccess` variable. [[1]](diffhunk://#diff-9c7a8e8f880a8e0e6ad47bc5ca66c42946c497d7d2fbd5381e8608036f108c94R102-R108) [[2]](diffhunk://#diff-9c7a8e8f880a8e0e6ad47bc5ca66c42946c497d7d2fbd5381e8608036f108c94R121-R127)

* [`src/contracts/relay-adapt/relay-adapt-versioned-smart-contracts.ts`](diffhunk://#diff-55dac9d69fcb5ff53149ca0e0329568fc664a2f3b8ba9c9b4b93e4fa45850170R37): Updated methods to propagate the newly added `sendWithPublicWallet` and `useDummyProof` parameters to the appropriate transaction handling logic. [[1]](diffhunk://#diff-55dac9d69fcb5ff53149ca0e0329568fc664a2f3b8ba9c9b4b93e4fa45850170R37) [[2]](diffhunk://#diff-55dac9d69fcb5ff53149ca0e0329568fc664a2f3b8ba9c9b4b93e4fa45850170R46) [[3]](diffhunk://#diff-55dac9d69fcb5ff53149ca0e0329568fc664a2f3b8ba9c9b4b93e4fa45850170R107) [[4]](diffhunk://#diff-55dac9d69fcb5ff53149ca0e0329568fc664a2f3b8ba9c9b4b93e4fa45850170R116)

### Updates to test cases:

* [`src/contracts/relay-adapt/__tests__/relay-adapt.test.ts`](diffhunk://#diff-43a63406ba0fe65a604a8b4307cc83fa679a3de678a44fef9c9f8b8d2992fb0eR291): Modified test cases to include the new `useDummyProof` and `sendWithPublicWallet` parameters, ensuring the updated functionality is properly tested. [[1]](diffhunk://#diff-43a63406ba0fe65a604a8b4307cc83fa679a3de678a44fef9c9f8b8d2992fb0eR291) [[2]](diffhunk://#diff-43a63406ba0fe65a604a8b4307cc83fa679a3de678a44fef9c9f8b8d2992fb0eR352) [[3]](diffhunk://#diff-43a63406ba0fe65a604a8b4307cc83fa679a3de678a44fef9c9f8b8d2992fb0eR389)

* [`src/validation/__tests__/extract-transaction-data.test.ts`](diffhunk://#diff-6da6e35c6ae1f3c2795baf8a67c24fa9d34a09c8192a3c42e7d226543c5cda02R305): Added `useDummyProof` parameter to relevant test cases to validate its integration with transaction data extraction logic. [[1]](diffhunk://#diff-6da6e35c6ae1f3c2795baf8a67c24fa9d34a09c8192a3c42e7d226543c5cda02R305) [[2]](diffhunk://#diff-6da6e35c6ae1f3c2795baf8a67c24fa9d34a09c8192a3c42e7d226543c5cda02R346)

### Minor updates:

* [`src/contracts/railgun-smart-wallet/V2/__tests__/railgun-smart-wallet-events.test.ts`](diffhunk://#diff-af86fc151160bf605bd6f2bd98afa5ee7c28a77feef7cad9a778afb34113ac97L110-R110): Updated the provider URL in the test setup to use a new RPC endpoint (`https://eth.llamarpc.com`) instead of the previous one (`https://rpc.ankr.com/eth`).