### PR TITLE
fix: verify decrypted transact note hash matches on-chain commitment

### DIFF
--- a/src/note/__tests__/transact-note.test.ts
+++ b/src/note/__tests__/transact-note.test.ts
@@ -433,7 +433,7 @@ describe('transact-note', () => {
         expect(decrypted.tokenHash).to.equal(note.tokenHash);
         expect(decrypted.value).to.equal(note.value);
         expect(decrypted.random).to.equal(note.random);
-        // expect(decrypted.hash).to.equal(note.hash);
+        expect(decrypted.hash).to.equal(note.hash);
         expect(decrypted.memoText).to.equal(note.memoText);
 
         // Check if vector encrypted values are successfully decrypted
@@ -457,8 +457,7 @@ describe('transact-note', () => {
         expect(decryptedFromCiphertext.tokenHash).to.equal(note.tokenHash);
         expect(decryptedFromCiphertext.value).to.equal(note.value);
         expect(decryptedFromCiphertext.random).to.equal(note.random);
-        // TODO: Update vectors for note hashes
-        // expect(decryptedFromCiphertext.hash).to.equal(note.hash);
+        expect(decryptedFromCiphertext.hash).to.equal(note.hash);
         expect(decryptedFromCiphertext.memoText).to.equal(note.memoText);
         expect(decryptedFromCiphertext.receiverAddressData.masterPublicKey).to.equal(
           address.masterPublicKey,

--- a/src/wallet/__tests__/railgun-wallet.test.ts
+++ b/src/wallet/__tests__/railgun-wallet.test.ts
@@ -2,20 +2,34 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { utf8ToBytes } from 'ethereum-cryptography/utils';
 import memdown from 'memdown';
-import { verifyED25519 } from '../../utils/keys-utils';
+import {
+  getNoteBlindingKeys,
+  getSharedSymmetricKey,
+  verifyED25519,
+} from '../../utils/keys-utils';
 import { RailgunWallet } from '../railgun-wallet';
 import { ViewOnlyWallet } from '../view-only-wallet';
 import { config } from '../../test/config.test';
 import { Chain, ChainType } from '../../models/engine-types';
 import { Database } from '../../database/database';
 import { sha256 } from '../../utils/hash';
-import { ByteUtils } from '../../utils/bytes';
+import { ByteLength, ByteUtils } from '../../utils/bytes';
 import { RailgunEngine } from '../../railgun-engine';
 import { Mnemonic } from '../../key-derivation/bip39';
 import { UTXOMerkletree } from '../../merkletree/utxo-merkletree';
 import { Prover } from '../../prover/prover';
 import { getTestTXIDVersion, testArtifactsGetter } from '../../test/helper.test';
 import { addChainSupportsV3 } from '../../chain/chain';
+import { TransactNote, getTokenDataERC20 } from '../../note';
+import { TXIDVersion } from '../../models/poi-types';
+import {
+  CommitmentCiphertextV2,
+  CommitmentType,
+  OutputType,
+  TransactCommitmentV2,
+} from '../../models/formatted-types';
+import WalletInfo from '../wallet-info';
+import { isDefined } from '../../utils/is-defined';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -213,6 +227,103 @@ describe('railgun-wallet', () => {
       treeScannedHeights: [],
       creationTree: undefined,
       creationTreeHeight: undefined,
+    });
+  });
+
+  describe('createScannedDBCommitments — transact commitment hash verification', () => {
+    // Genuinely-encrypted self-transfer note that decrypts cleanly for `wallet`.
+    const encryptOwnTransactNote = async () => {
+      WalletInfo.setWalletSource('test');
+      const tokenData = getTokenDataERC20('0x5fbdb2315678afecb367f032d93f642f64180aa3');
+      const note = TransactNote.createTransfer(
+        wallet.addressKeys,
+        wallet.addressKeys,
+        1000n,
+        tokenData,
+        false, // showSenderAddressToRecipient
+        OutputType.Transfer,
+        undefined, // memoText
+      );
+      const { senderRandom } = note;
+      if (!isDefined(senderRandom)) {
+        throw new Error('Test setup: senderRandom undefined');
+      }
+      const viewingKeyPair = wallet.getViewingKeyPair();
+      const blindingKeys = getNoteBlindingKeys(
+        viewingKeyPair.pubkey,
+        wallet.addressKeys.viewingPublicKey,
+        note.random,
+        senderRandom,
+      );
+      const sharedKey = await getSharedSymmetricKey(
+        viewingKeyPair.privateKey,
+        blindingKeys.blindedReceiverViewingKey,
+      );
+      if (!isDefined(sharedKey)) {
+        throw new Error('Test setup: shared key undefined');
+      }
+      const { noteCiphertext, noteMemo, annotationData } = note.encryptV2(
+        TXIDVersion.V2_PoseidonMerkle,
+        sharedKey,
+        wallet.addressKeys.masterPublicKey,
+        senderRandom,
+        viewingKeyPair.privateKey,
+      );
+      const ciphertext: CommitmentCiphertextV2 = {
+        ciphertext: noteCiphertext,
+        blindedSenderViewingKey: ByteUtils.hexlify(blindingKeys.blindedSenderViewingKey),
+        blindedReceiverViewingKey: ByteUtils.hexlify(blindingKeys.blindedReceiverViewingKey),
+        annotationData,
+        memo: noteMemo,
+      };
+      return { note, ciphertext };
+    };
+
+    const makeV2Leaf = (
+      ciphertext: CommitmentCiphertextV2,
+      hash: string,
+    ): TransactCommitmentV2 => ({
+      commitmentType: CommitmentType.TransactCommitmentV2,
+      hash,
+      txid: ByteUtils.formatToByteLength('00', ByteLength.UINT_256),
+      timestamp: undefined,
+      blockNumber: 0,
+      utxoTree: 0,
+      utxoIndex: 0,
+      railgunTxid: undefined,
+      ciphertext,
+    });
+
+    it('Should store a receive commitment when the decrypted note hash matches', async () => {
+      const { note, ciphertext } = await encryptOwnTransactNote();
+      const matchingHash = ByteUtils.nToHex(note.hash, ByteLength.UINT_256);
+      await wallet.scanLeaves(
+        TXIDVersion.V2_PoseidonMerkle,
+        [makeV2Leaf(ciphertext, matchingHash)],
+        0, // tree
+        chain,
+        0, // startScanHeight
+        undefined, // scanTicker
+      );
+      const key = wallet.getWalletReceiveCommitmentDBPrefix(chain, 0, 0);
+      await expect(db.get(key)).to.be.fulfilled;
+    });
+
+    it('Should discard a decrypted note whose hash does not match the commitment', async () => {
+      const { note, ciphertext } = await encryptOwnTransactNote();
+      // Pair the genuine, cleanly-decrypting ciphertext with a different
+      // (but well-formed) on-chain commitment hash — the attack this fix blocks.
+      const tamperedHash = ByteUtils.nToHex(note.hash + 1n, ByteLength.UINT_256);
+      await wallet.scanLeaves(
+        TXIDVersion.V2_PoseidonMerkle,
+        [makeV2Leaf(ciphertext, tamperedHash)],
+        0, // tree
+        chain,
+        0, // startScanHeight
+        undefined, // scanTicker
+      );
+      const key = wallet.getWalletReceiveCommitmentDBPrefix(chain, 0, 0);
+      await expect(db.get(key)).to.be.rejected;
     });
   });
 

--- a/src/wallet/abstract-wallet.ts
+++ b/src/wallet/abstract-wallet.ts
@@ -550,6 +550,14 @@ abstract class AbstractWallet extends EventEmitter {
     const walletAddress = this.getAddress();
     const commitmentType: CommitmentType = AbstractWallet.getCommitmentType(leaf);
 
+    // SECURITY: a decrypted transact note must re-hash to the on-chain commitment
+    // hash; one that decrypts cleanly but hashes differently is tampered/corrupt.
+    const decryptedNoteMatchesCommitment = (note: TransactNote): boolean => {
+      const noteHash = ByteUtils.nToHex(note.hash, ByteLength.UINT_256);
+      const commitmentHash = ByteUtils.formatToByteLength(leaf.hash, ByteLength.UINT_256);
+      return noteHash === commitmentHash;
+    };
+
     switch (commitmentType) {
       case CommitmentType.TransactCommitmentV2: {
         const commitment = leaf as TransactCommitmentV2;
@@ -578,6 +586,10 @@ abstract class AbstractWallet extends EventEmitter {
             leaf.blockNumber,
             undefined, // transactCommitmentBatchIndex
           );
+          if (noteReceive && !decryptedNoteMatchesCommitment(noteReceive)) {
+            EngineDebug.log('Discarding decrypted receive note: hash does not match commitment.');
+            noteReceive = undefined;
+          }
           serializedNoteReceive = noteReceive ? noteReceive.serialize() : undefined;
         }
         if (sharedKeySender) {
@@ -595,6 +607,10 @@ abstract class AbstractWallet extends EventEmitter {
             leaf.blockNumber,
             undefined, // transactCommitmentBatchIndex
           );
+          if (noteSend && !decryptedNoteMatchesCommitment(noteSend)) {
+            EngineDebug.log('Discarding decrypted send note: hash does not match commitment.');
+            noteSend = undefined;
+          }
           serializedNoteSend = noteSend ? noteSend.serialize() : undefined;
         }
         break;
@@ -667,6 +683,10 @@ abstract class AbstractWallet extends EventEmitter {
             leaf.blockNumber,
             commitment.transactCommitmentBatchIndex,
           );
+          if (noteReceive && !decryptedNoteMatchesCommitment(noteReceive)) {
+            EngineDebug.log('Discarding decrypted receive note: hash does not match commitment.');
+            noteReceive = undefined;
+          }
           serializedNoteReceive = noteReceive ? noteReceive.serialize() : undefined;
         }
         if (sharedKeySender) {
@@ -684,6 +704,10 @@ abstract class AbstractWallet extends EventEmitter {
             leaf.blockNumber,
             commitment.transactCommitmentBatchIndex,
           );
+          if (noteSend && !decryptedNoteMatchesCommitment(noteSend)) {
+            EngineDebug.log('Discarding decrypted send note: hash does not match commitment.');
+            noteSend = undefined;
+          }
           serializedNoteSend = noteSend ? noteSend.serialize() : undefined;
         }
         break;
@@ -721,6 +745,10 @@ abstract class AbstractWallet extends EventEmitter {
             leaf.blockNumber,
             undefined, // transactCommitmentBatchIndex
           );
+          if (noteReceive && !decryptedNoteMatchesCommitment(noteReceive)) {
+            EngineDebug.log('Discarding decrypted receive note: hash does not match commitment.');
+            noteReceive = undefined;
+          }
           serializedNoteReceive = noteReceive
             ? noteReceive.serializeLegacy(viewingPrivateKey)
             : undefined;
@@ -740,6 +768,10 @@ abstract class AbstractWallet extends EventEmitter {
             leaf.blockNumber,
             undefined, // transactCommitmentBatchIndex
           );
+          if (noteSend && !decryptedNoteMatchesCommitment(noteSend)) {
+            EngineDebug.log('Discarding decrypted send note: hash does not match commitment.');
+            noteSend = undefined;
+          }
           serializedNoteSend = noteSend ? noteSend.serializeLegacy(viewingPrivateKey) : undefined;
         }
         break;


### PR DESCRIPTION
createScannedDBCommitments decrypted transact-note ciphertexts and trusted the result without re-hashing. A crafted ciphertext that decrypts cleanly to a note whose poseidon hash differs from the on-chain commitment hash would be recorded as a phantom balance.

Gate all six decryption sites (V2/V3/Legacy x receive/send): recompute the note hash and compare it to leaf.hash, discarding the note on a mismatch. Fail-soft (log + drop) to match the existing extractERC20AmountFromTransactNote precedent.

Add scan-path coverage in railgun-wallet.test.ts and re-enable the previously commented-out hash assertions in transact-note.test.ts.