### PR TITLE
Add mnemonic password wallet flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Others
 RAILGUN Wallet
 
 - `railgunEngine.createWalletFromMnemonic()` (instance method)
+- `railgunEngine.createWalletFromMnemonicWithPassword()` (instance method)
 - `railgunEngine.loadExistingWallet()` (instance method)
 
 View-only RAILGUN Wallet

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ RAILGUN Wallet
 
 - `railgunEngine.createWalletFromMnemonic()` (instance method)
 - `railgunEngine.createWalletFromMnemonicWithPassword()` (instance method)
+  - The BIP39 mnemonic password is **not stored** by the engine. The caller owns it and
+    must supply it again to `loadExistingWallet()` and to every spend.
 - `railgunEngine.loadExistingWallet()` (instance method)
+  - Pass the BIP39 mnemonic password as the third argument for wallets created with one.
 
 View-only RAILGUN Wallet
 

--- a/src/key-derivation/bip39.ts
+++ b/src/key-derivation/bip39.ts
@@ -34,17 +34,25 @@ export class Mnemonic {
   /**
    * For deriving 0x private key from mnemonic and derivation index. Not for use with 0zk.
    */
-  static to0xPrivateKey(mnemonic: string, derivationIndex?: number): string {
-    const seed = mnemonicToSeedSync(mnemonic);
+  static to0xPrivateKey(
+    mnemonic: string,
+    derivationIndex?: number,
+    password: string = '',
+  ): string {
+    const seed = mnemonicToSeedSync(mnemonic, password);
     const path = getPath(derivationIndex);
     const node = HDKey.fromMasterSeed(seed).derive(path);
     const privateKey = bytesToHex(node.privateKey as Uint8Array);
     return privateKey;
   }
 
-  static to0xAddress(mnemonic: string, derivationIndex?: number): string {
+  static to0xAddress(
+    mnemonic: string,
+    derivationIndex?: number,
+    password: string = '',
+  ): string {
     const path = getPath(derivationIndex);
-    const wallet = HDNodeWallet.fromMnemonic(EthersMnemonic.fromPhrase(mnemonic), path);
+    const wallet = HDNodeWallet.fromMnemonic(EthersMnemonic.fromPhrase(mnemonic, password), path);
     return wallet.address;
   }
 }

--- a/src/key-derivation/wallet-node.ts
+++ b/src/key-derivation/wallet-node.ts
@@ -29,13 +29,17 @@ const derivePathsForIndex = (index: number = 0) => {
   };
 };
 
-export const deriveNodes = (mnemonic: string, index: number = 0): WalletNodes => {
+export const deriveNodes = (
+  mnemonic: string,
+  index: number = 0,
+  password: string = '',
+): WalletNodes => {
   const paths = derivePathsForIndex(index);
   return {
     // eslint-disable-next-line no-use-before-define
-    spending: WalletNode.fromMnemonic(mnemonic).derive(paths.spending),
+    spending: WalletNode.fromMnemonic(mnemonic, password).derive(paths.spending),
     // eslint-disable-next-line no-use-before-define
-    viewing: WalletNode.fromMnemonic(mnemonic).derive(paths.viewing),
+    viewing: WalletNode.fromMnemonic(mnemonic, password).derive(paths.viewing),
   };
 };
 
@@ -57,8 +61,8 @@ export class WalletNode {
    * Create BIP32 node from mnemonic
    * @returns {WalletNode}
    */
-  static fromMnemonic(mnemonic: string): WalletNode {
-    const seed = Mnemonic.toSeed(mnemonic);
+  static fromMnemonic(mnemonic: string, password: string = ''): WalletNode {
+    const seed = Mnemonic.toSeed(mnemonic, password);
     return new WalletNode(getMasterKeyFromSeed(seed));
   }
 

--- a/src/models/wallet-types.ts
+++ b/src/models/wallet-types.ts
@@ -36,7 +36,6 @@ export type AddressKeys = {
 
 export type WalletData = {
   mnemonic: string;
-  mnemonicPassword?: string;
   index: number;
   creationBlockNumbers: Optional<number[][]>;
 };

--- a/src/models/wallet-types.ts
+++ b/src/models/wallet-types.ts
@@ -36,6 +36,7 @@ export type AddressKeys = {
 
 export type WalletData = {
   mnemonic: string;
+  mnemonicPassword?: string;
   index: number;
   creationBlockNumbers: Optional<number[][]>;
 };

--- a/src/railgun-engine.ts
+++ b/src/railgun-engine.ts
@@ -2098,13 +2098,25 @@ class RailgunEngine extends EventEmitter {
    * Load existing wallet
    * @param {string} encryptionKey - encryption key of wallet
    * @param {string} id - wallet ID
+   * @param {string} mnemonicPassword - BIP39 mnemonic password, if the wallet was created
+   *   with one. Not stored by the engine; must be supplied on every load (and on spend).
    * @returns id
    */
-  async loadExistingWallet(encryptionKey: string, id: string): Promise<RailgunWallet> {
+  async loadExistingWallet(
+    encryptionKey: string,
+    id: string,
+    mnemonicPassword?: string,
+  ): Promise<RailgunWallet> {
     if (isDefined(this.wallets[id])) {
       return this.wallets[id] as RailgunWallet;
     }
-    const wallet = await RailgunWallet.loadExisting(this.db, encryptionKey, id, this.prover);
+    const wallet = await RailgunWallet.loadExisting(
+      this.db,
+      encryptionKey,
+      id,
+      this.prover,
+      mnemonicPassword,
+    );
     await this.loadWallet(wallet);
     return wallet;
   }

--- a/src/railgun-engine.ts
+++ b/src/railgun-engine.ts
@@ -2182,6 +2182,30 @@ class RailgunEngine extends EventEmitter {
     return wallet;
   }
 
+  /**
+   * Creates wallet from mnemonic and BIP39 mnemonic password.
+   * The mnemonic password is distinct from the wallet database encryption key.
+   */
+  async createWalletFromMnemonicWithPassword(
+    encryptionKey: string,
+    mnemonic: string,
+    mnemonicPassword: string,
+    index: number = 0,
+    creationBlockNumbers: Optional<number[][]> = undefined,
+  ): Promise<RailgunWallet> {
+    const wallet = await RailgunWallet.fromMnemonicWithPassword(
+      this.db,
+      encryptionKey,
+      mnemonic,
+      mnemonicPassword,
+      index,
+      creationBlockNumbers,
+      this.prover,
+    );
+    await this.loadWallet(wallet);
+    return wallet;
+  }
+
   async createViewOnlyWalletFromShareableViewingKey(
     encryptionKey: string,
     shareableViewingKey: string,

--- a/src/transaction/__tests__/transaction-erc20.test.ts
+++ b/src/transaction/__tests__/transaction-erc20.test.ts
@@ -850,6 +850,31 @@ describe('transaction-erc20', function test() {
     assert.isTrue(verifyEDDSA(msg, signature, pubkey));
 
     expect(signature).to.deep.equal(signEDDSA(privateKey, msg));
+
+    const mnemonicPassword = 'test mnemonic password';
+    const passwordWallet = await RailgunWallet.fromMnemonicWithPassword(
+      db,
+      testEncryptionKey,
+      testMnemonic,
+      mnemonicPassword,
+      0,
+      undefined,
+      prover,
+    );
+    const signatureWithMnemonicPassword = await wallet.sign(
+      publicInputs,
+      testEncryptionKey,
+      mnemonicPassword,
+    );
+    const passwordSpendingKeyPair = await passwordWallet.getSpendingKeyPair(testEncryptionKey);
+
+    assert.isTrue(
+      verifyEDDSA(
+        msg,
+        signatureWithMnemonicPassword,
+        passwordSpendingKeyPair.pubkey,
+      ),
+    );
   });
 
   it('Should request one hardware wallet batch approval and sign with the returned sub-session', async () => {

--- a/src/transaction/__tests__/transaction-erc20.test.ts
+++ b/src/transaction/__tests__/transaction-erc20.test.ts
@@ -851,6 +851,8 @@ describe('transaction-erc20', function test() {
 
     expect(signature).to.deep.equal(signEDDSA(privateKey, msg));
 
+    // Mnemonic-password wallet: the password is supplied (never stored) and must be
+    // threaded through sign -> getSpendingKeyPair to derive the correct spending key.
     const mnemonicPassword = 'test mnemonic password';
     const passwordWallet = await RailgunWallet.fromMnemonicWithPassword(
       db,
@@ -861,20 +863,32 @@ describe('transaction-erc20', function test() {
       undefined,
       prover,
     );
-    const signatureWithMnemonicPassword = await wallet.sign(
+    const passwordSpendingKeyPair = await passwordWallet.getSpendingKeyPair(
+      testEncryptionKey,
+      mnemonicPassword,
+    );
+    const signatureWithMnemonicPassword = await passwordWallet.sign(
       publicInputs,
       testEncryptionKey,
       mnemonicPassword,
     );
-    const passwordSpendingKeyPair = await passwordWallet.getSpendingKeyPair(testEncryptionKey);
 
     assert.isTrue(
-      verifyEDDSA(
-        msg,
-        signatureWithMnemonicPassword,
-        passwordSpendingKeyPair.pubkey,
-      ),
+      verifyEDDSA(msg, signatureWithMnemonicPassword, passwordSpendingKeyPair.pubkey),
     );
+    expect(signatureWithMnemonicPassword).to.deep.equal(
+      signEDDSA(passwordSpendingKeyPair.privateKey, msg),
+    );
+
+    // Signing a mnemonic-password wallet without the password must fail loudly rather
+    // than silently derive a different, unrelated key.
+    await expect(passwordWallet.sign(publicInputs, testEncryptionKey)).to.be.rejectedWith(
+      'Incorrect mnemonic password for wallet.',
+    );
+    // Supplying a password for a wallet that has none must likewise fail.
+    await expect(
+      wallet.sign(publicInputs, testEncryptionKey, mnemonicPassword),
+    ).to.be.rejectedWith('Incorrect mnemonic password for wallet.');
   });
 
   it('Should request one hardware wallet batch approval and sign with the returned sub-session', async () => {

--- a/src/transaction/transaction-batch.ts
+++ b/src/transaction/transaction-batch.ts
@@ -371,6 +371,7 @@ export class TransactionBatch {
     progressCallback: (progress: number, status: string) => void,
     shouldGeneratePreTransactionPOIs: boolean,
     originShieldTxidForSpendabilityOverride?: string,
+    mnemonicPassword?: string,
   ): Promise<{
     provedTransactions: (TransactionStructV2 | TransactionStructV3)[];
     preTransactionPOIsPerTxidLeafPerList: PreTransactionPOIsPerTxidLeafPerList;
@@ -446,6 +447,7 @@ export class TransactionBatch {
           txidVersion,
           encryptionKey,
           globalBoundParams,
+          mnemonicPassword,
         );
 
       generatedRequests.push({
@@ -477,6 +479,7 @@ export class TransactionBatch {
       const signature = await wallet.sign(
         publicInputs,
         wallet instanceof HardwareWallet ? (subSession ?? '') : encryptionKey,
+        wallet instanceof HardwareWallet ? undefined : mnemonicPassword,
       );
 
       // Specific types per TXIDVersion
@@ -590,6 +593,7 @@ export class TransactionBatch {
     txidVersion: TXIDVersion,
     encryptionKey: string,
     originShieldTxidForSpendabilityOverride?: string,
+    mnemonicPassword?: string,
   ): Promise<(TransactionStructV2 | TransactionStructV3)[]> {
     const spendingSolutionGroups = await this.generateValidSpendingSolutionGroupsAllOutputs(
       wallet,
@@ -619,6 +623,7 @@ export class TransactionBatch {
         txidVersion,
         encryptionKey,
         globalBoundParams,
+        mnemonicPassword,
       );
       // eslint-disable-next-line no-await-in-loop
       const dummyProvedTransaction = await transaction.generateDummyProvedTransaction(

--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -135,10 +135,11 @@ class Transaction {
     txidVersion: TXIDVersion,
     encryptionKey: string,
     globalBoundParams: PoseidonMerkleVerifier.GlobalBoundParamsStruct,
+    mnemonicPassword?: string,
   ): Promise<RailgunTransactionRequest> {
     const merkletree = wallet.getUTXOMerkletree(txidVersion, this.chain);
     const merkleRoot = await merkletree.getRoot(this.spendingTree);
-    const spendingKey = await wallet.getSpendingKeyPair(encryptionKey);
+    const spendingKey = await wallet.getSpendingKeyPair(encryptionKey, mnemonicPassword);
     const nullifyingKey = wallet.getNullifyingKey();
     const senderViewingKeys = wallet.getViewingKeyPair();
 

--- a/src/wallet/__tests__/railgun-wallet.test.ts
+++ b/src/wallet/__tests__/railgun-wallet.test.ts
@@ -96,18 +96,75 @@ describe('railgun-wallet', () => {
       new Prover(testArtifactsGetter),
     );
 
+    // A mnemonic password produces a distinct wallet from the no-password wallet.
+    expect(passwordWallet.id).to.not.equal(wallet.id);
+
+    // The mnemonic password is never stored, so it must be supplied again on load.
     const loadedWallet = await RailgunWallet.loadExisting(
       db,
       testEncryptionKey,
       passwordWallet.id,
       new Prover(testArtifactsGetter),
+      mnemonicPassword,
     );
 
-    expect(passwordWallet.id).to.not.equal(wallet.id);
     expect(loadedWallet.id).to.equal(passwordWallet.id);
-    expect(await loadedWallet.getChainAddress(testEncryptionKey)).to.equal(
-      await passwordWallet.getChainAddress(testEncryptionKey),
+    expect(await loadedWallet.getChainAddress(testEncryptionKey, mnemonicPassword)).to.equal(
+      await passwordWallet.getChainAddress(testEncryptionKey, mnemonicPassword),
     );
+    // The chain address also differs from the no-password wallet.
+    expect(
+      await passwordWallet.getChainAddress(testEncryptionKey, mnemonicPassword),
+    ).to.not.equal(await wallet.getChainAddress(testEncryptionKey));
+  });
+
+  it('Should produce the same id/address for a no-password wallet (regression)', async () => {
+    // Loading without a password must reproduce the wallet unchanged — guards the
+    // empty-passphrase derivation path against regressions.
+    const loadedWallet = await RailgunWallet.loadExisting(
+      db,
+      testEncryptionKey,
+      wallet.id,
+      new Prover(testArtifactsGetter),
+    );
+    expect(loadedWallet.id).to.equal(wallet.id);
+    expect(await loadedWallet.getChainAddress(testEncryptionKey)).to.equal(
+      await wallet.getChainAddress(testEncryptionKey),
+    );
+  });
+
+  it('Should reject loading a mnemonic-password wallet with a wrong/missing password', async () => {
+    const mnemonicPassword = 'test mnemonic password';
+    const passwordWallet = await RailgunWallet.fromMnemonicWithPassword(
+      db,
+      testEncryptionKey,
+      testMnemonic,
+      mnemonicPassword,
+      0,
+      undefined, // creationBlockNumbers
+      new Prover(testArtifactsGetter),
+    );
+
+    // Missing password.
+    await expect(
+      RailgunWallet.loadExisting(
+        db,
+        testEncryptionKey,
+        passwordWallet.id,
+        new Prover(testArtifactsGetter),
+      ),
+    ).to.be.rejectedWith('Incorrect mnemonic password for wallet.');
+
+    // Wrong password.
+    await expect(
+      RailgunWallet.loadExisting(
+        db,
+        testEncryptionKey,
+        passwordWallet.id,
+        new Prover(testArtifactsGetter),
+        'wrong password',
+      ),
+    ).to.be.rejectedWith('Incorrect mnemonic password for wallet.');
   });
 
   it('Should load existing view-only wallet', async () => {

--- a/src/wallet/__tests__/railgun-wallet.test.ts
+++ b/src/wallet/__tests__/railgun-wallet.test.ts
@@ -84,6 +84,32 @@ describe('railgun-wallet', () => {
     expect(wallet2.id).to.equal(wallet.id);
   });
 
+  it('Should load existing wallet with mnemonic password', async () => {
+    const mnemonicPassword = 'test mnemonic password';
+    const passwordWallet = await RailgunWallet.fromMnemonicWithPassword(
+      db,
+      testEncryptionKey,
+      testMnemonic,
+      mnemonicPassword,
+      0,
+      undefined, // creationBlockNumbers
+      new Prover(testArtifactsGetter),
+    );
+
+    const loadedWallet = await RailgunWallet.loadExisting(
+      db,
+      testEncryptionKey,
+      passwordWallet.id,
+      new Prover(testArtifactsGetter),
+    );
+
+    expect(passwordWallet.id).to.not.equal(wallet.id);
+    expect(loadedWallet.id).to.equal(passwordWallet.id);
+    expect(await loadedWallet.getChainAddress(testEncryptionKey)).to.equal(
+      await passwordWallet.getChainAddress(testEncryptionKey),
+    );
+  });
+
   it('Should load existing view-only wallet', async () => {
     const viewOnlyWallet2 = await ViewOnlyWallet.loadExisting(
       db,

--- a/src/wallet/railgun-wallet.ts
+++ b/src/wallet/railgun-wallet.ts
@@ -17,13 +17,20 @@ class RailgunWallet extends AbstractWallet {
    * Spending key should be kept private and only accessed on demand
    * @returns {Promise<SpendingKeyPair>}
    */
-  async getSpendingKeyPair(encryptionKey: string): Promise<SpendingKeyPair> {
-    const node = await this.loadSpendingKey(encryptionKey);
+  async getSpendingKeyPair(
+    encryptionKey: string,
+    mnemonicPassword?: string,
+  ): Promise<SpendingKeyPair> {
+    const node = await this.loadSpendingKey(encryptionKey, mnemonicPassword);
     return node.getSpendingKeyPair();
   }
 
-  async sign(publicInputs: PublicInputsRailgun, encryptionKey: string): Promise<Signature> {
-    const spendingKeyPair = await this.getSpendingKeyPair(encryptionKey);
+  async sign(
+    publicInputs: PublicInputsRailgun,
+    encryptionKey: string,
+    mnemonicPassword?: string,
+  ): Promise<Signature> {
+    const spendingKeyPair = await this.getSpendingKeyPair(encryptionKey, mnemonicPassword);
     const msg = poseidon([publicInputs.merkleRoot, publicInputs.boundParamsHash, ...publicInputs.nullifiers, ...publicInputs.commitmentsOut]);
     return signEDDSA(spendingKeyPair.privateKey, msg);
   }
@@ -33,44 +40,54 @@ class RailgunWallet extends AbstractWallet {
    * @param {BytesData} encryptionKey
    * @returns {Node} BabyJubJub node
    */
-  private async loadSpendingKey(encryptionKey: string): Promise<WalletNode> {
-    const { mnemonic, index } = (await RailgunWallet.read(
+  private async loadSpendingKey(
+    encryptionKey: string,
+    mnemonicPasswordOverride?: string,
+  ): Promise<WalletNode> {
+    const { mnemonic, mnemonicPassword, index } = (await RailgunWallet.read(
       this.db,
       this.id,
       encryptionKey,
     )) as WalletData;
-    return deriveNodes(mnemonic, index).spending;
+    return deriveNodes(mnemonic, index, mnemonicPasswordOverride ?? mnemonicPassword).spending;
   }
 
   /**
    * Helper to get the ethereum/whatever address is associated with this wallet
    */
   async getChainAddress(encryptionKey: string): Promise<string> {
-    const { mnemonic, index } = (await AbstractWallet.read(
+    const { mnemonic, mnemonicPassword, index } = (await AbstractWallet.read(
       this.db,
       this.id,
       encryptionKey,
     )) as WalletData;
-    return Mnemonic.to0xAddress(mnemonic, index);
+    return Mnemonic.to0xAddress(mnemonic, index, mnemonicPassword);
   }
 
   /**
    * Calculate Wallet ID from mnemonic and derivation path index
    * @returns {string} hash of mnemonic and index
    */
-  private static generateID(mnemonic: string, index: number): string {
-    return sha256(ByteUtils.combine([Mnemonic.toSeed(mnemonic), index.toString(16)]));
+  private static generateID(
+    mnemonic: string,
+    index: number,
+    mnemonicPassword: string = '',
+  ): string {
+    return sha256(
+      ByteUtils.combine([Mnemonic.toSeed(mnemonic, mnemonicPassword), index.toString(16)]),
+    );
   }
 
   private static async createWallet(
     id: string,
     db: Database,
     mnemonic: string,
+    mnemonicPassword: string,
     index: number,
     creationBlockNumbers: Optional<number[][]>,
     prover: Prover,
   ) {
-    const nodes = deriveNodes(mnemonic, index);
+    const nodes = deriveNodes(mnemonic, index, mnemonicPassword);
 
     const viewingKeyPair = await nodes.viewing.getViewingKeyPair();
     const spendingPublicKey = nodes.spending.getSpendingKeyPair().pubkey;
@@ -100,12 +117,47 @@ class RailgunWallet extends AbstractWallet {
     creationBlockNumbers: Optional<number[][]>,
     prover: Prover,
   ): Promise<RailgunWallet> {
-    const id = RailgunWallet.generateID(mnemonic, index);
+    return this.fromMnemonicWithPassword(
+      db,
+      encryptionKey,
+      mnemonic,
+      '', // mnemonicPassword
+      index,
+      creationBlockNumbers,
+      prover,
+    );
+  }
+
+  /**
+   * Create a wallet from mnemonic and BIP39 mnemonic password.
+   */
+  static async fromMnemonicWithPassword(
+    db: Database,
+    encryptionKey: string,
+    mnemonic: string,
+    mnemonicPassword: string,
+    index: number,
+    creationBlockNumbers: Optional<number[][]>,
+    prover: Prover,
+  ): Promise<RailgunWallet> {
+    const id = RailgunWallet.generateID(mnemonic, index, mnemonicPassword);
 
     // Write encrypted mnemonic to DB
-    await AbstractWallet.write(db, id, encryptionKey, { mnemonic, index, creationBlockNumbers });
+    const walletData: WalletData = { mnemonic, index, creationBlockNumbers };
+    if (mnemonicPassword !== '') {
+      walletData.mnemonicPassword = mnemonicPassword;
+    }
+    await AbstractWallet.write(db, id, encryptionKey, walletData);
 
-    return this.createWallet(id, db, mnemonic, index, creationBlockNumbers, prover);
+    return this.createWallet(
+      id,
+      db,
+      mnemonic,
+      mnemonicPassword,
+      index,
+      creationBlockNumbers,
+      prover,
+    );
   }
 
   /**
@@ -122,7 +174,7 @@ class RailgunWallet extends AbstractWallet {
     prover: Prover,
   ): Promise<RailgunWallet> {
     // Get encrypted mnemonic and index from DB
-    const { mnemonic, index, creationBlockNumbers } = (await AbstractWallet.read(
+    const { mnemonic, mnemonicPassword, index, creationBlockNumbers } = (await AbstractWallet.read(
       db,
       id,
       encryptionKey,
@@ -131,7 +183,15 @@ class RailgunWallet extends AbstractWallet {
       throw new Error('Incorrect wallet type.');
     }
 
-    return this.createWallet(id, db, mnemonic, index, creationBlockNumbers, prover);
+    return this.createWallet(
+      id,
+      db,
+      mnemonic,
+      mnemonicPassword ?? '',
+      index,
+      creationBlockNumbers,
+      prover,
+    );
   }
 }
 

--- a/src/wallet/railgun-wallet.ts
+++ b/src/wallet/railgun-wallet.ts
@@ -42,25 +42,28 @@ class RailgunWallet extends AbstractWallet {
    */
   private async loadSpendingKey(
     encryptionKey: string,
-    mnemonicPasswordOverride?: string,
+    mnemonicPassword?: string,
   ): Promise<WalletNode> {
-    const { mnemonic, mnemonicPassword, index } = (await RailgunWallet.read(
+    const { mnemonic, index } = (await RailgunWallet.read(
       this.db,
       this.id,
       encryptionKey,
     )) as WalletData;
-    return deriveNodes(mnemonic, index, mnemonicPasswordOverride ?? mnemonicPassword).spending;
+    RailgunWallet.assertMnemonicPasswordMatchesID(this.id, mnemonic, index, mnemonicPassword);
+    return deriveNodes(mnemonic, index, mnemonicPassword).spending;
   }
 
   /**
-   * Helper to get the ethereum/whatever address is associated with this wallet
+   * Helper to get the ethereum/whatever address is associated with this wallet.
+   * The BIP39 mnemonic password (if any) must be supplied; it is never stored.
    */
-  async getChainAddress(encryptionKey: string): Promise<string> {
-    const { mnemonic, mnemonicPassword, index } = (await AbstractWallet.read(
+  async getChainAddress(encryptionKey: string, mnemonicPassword?: string): Promise<string> {
+    const { mnemonic, index } = (await AbstractWallet.read(
       this.db,
       this.id,
       encryptionKey,
     )) as WalletData;
+    RailgunWallet.assertMnemonicPasswordMatchesID(this.id, mnemonic, index, mnemonicPassword);
     return Mnemonic.to0xAddress(mnemonic, index, mnemonicPassword);
   }
 
@@ -76,6 +79,23 @@ class RailgunWallet extends AbstractWallet {
     return sha256(
       ByteUtils.combine([Mnemonic.toSeed(mnemonic, mnemonicPassword), index.toString(16)]),
     );
+  }
+
+  /**
+   * The BIP39 mnemonic password is never persisted; it must be supplied by the caller
+   * on load and on every spend. Verify the supplied password reproduces this wallet's
+   * ID — a mismatch means the wrong (or a missing) password was supplied, which would
+   * otherwise silently derive a different, unrelated key. Fail loudly instead.
+   */
+  private static assertMnemonicPasswordMatchesID(
+    id: string,
+    mnemonic: string,
+    index: number,
+    mnemonicPassword: string = '',
+  ): void {
+    if (RailgunWallet.generateID(mnemonic, index, mnemonicPassword) !== id) {
+      throw new Error('Incorrect mnemonic password for wallet.');
+    }
   }
 
   private static async createWallet(
@@ -142,12 +162,10 @@ class RailgunWallet extends AbstractWallet {
   ): Promise<RailgunWallet> {
     const id = RailgunWallet.generateID(mnemonic, index, mnemonicPassword);
 
-    // Write encrypted mnemonic to DB
-    const walletData: WalletData = { mnemonic, index, creationBlockNumbers };
-    if (mnemonicPassword !== '') {
-      walletData.mnemonicPassword = mnemonicPassword;
-    }
-    await AbstractWallet.write(db, id, encryptionKey, walletData);
+    // Write encrypted mnemonic to DB. The BIP39 mnemonic password is intentionally NOT
+    // persisted: storing it next to the mnemonic would defeat its purpose as a second
+    // factor. The caller owns the password and must supply it on load and on spend.
+    await AbstractWallet.write(db, id, encryptionKey, { mnemonic, index, creationBlockNumbers });
 
     return this.createWallet(
       id,
@@ -172,9 +190,10 @@ class RailgunWallet extends AbstractWallet {
     encryptionKey: string,
     id: string,
     prover: Prover,
+    mnemonicPassword?: string,
   ): Promise<RailgunWallet> {
     // Get encrypted mnemonic and index from DB
-    const { mnemonic, mnemonicPassword, index, creationBlockNumbers } = (await AbstractWallet.read(
+    const { mnemonic, index, creationBlockNumbers } = (await AbstractWallet.read(
       db,
       id,
       encryptionKey,
@@ -182,6 +201,10 @@ class RailgunWallet extends AbstractWallet {
     if (!mnemonic) {
       throw new Error('Incorrect wallet type.');
     }
+    // The mnemonic password is not stored — the supplied one must reproduce this wallet's
+    // ID. Verifying here turns a wrong/missing password into a clear error instead of
+    // silently loading a different, unrelated wallet's keys.
+    RailgunWallet.assertMnemonicPasswordMatchesID(id, mnemonic, index, mnemonicPassword);
 
     return this.createWallet(
       id,


### PR DESCRIPTION
This pull request adds support for BIP39 mnemonic passwords (often called "passphrases") to the wallet creation, loading, key derivation, and signing flows. The mnemonic password is never stored; instead, it must be supplied by the caller whenever needed (such as on wallet load or spend). The changes ensure that using the wrong or missing password fails loudly, preventing silent derivation of unrelated keys. The update also includes comprehensive tests and documentation for this new feature.

**Mnemonic password support and enforcement:**

* Added support for creating wallets with a BIP39 mnemonic password via the new `RailgunWallet.fromMnemonicWithPassword` and `railgunEngine.createWalletFromMnemonicWithPassword()` methods. The password is never stored and must be supplied whenever the wallet is loaded or used for spending. [[1]](diffhunk://#diff-021b0fef3d8b0734b70d025521d0eaf86c6dfd5b644d4ed8bd2b8ae143f20a7bL103-R178) [[2]](diffhunk://#diff-4bdbc1d9079555ae4e1178a2910b8f846950e27b2b81897d5fc3aafeddd10ab8R2197-R2220) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R48)
* Updated wallet loading (`RailgunWallet.loadExisting` and `railgunEngine.loadExistingWallet`) to require the mnemonic password for wallets created with one, and to verify that the supplied password matches the wallet’s ID, failing if not. [[1]](diffhunk://#diff-021b0fef3d8b0734b70d025521d0eaf86c6dfd5b644d4ed8bd2b8ae143f20a7bR193) [[2]](diffhunk://#diff-021b0fef3d8b0734b70d025521d0eaf86c6dfd5b644d4ed8bd2b8ae143f20a7bR204-R217) [[3]](diffhunk://#diff-4bdbc1d9079555ae4e1178a2910b8f846950e27b2b81897d5fc3aafeddd10ab8R2101-R2119) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R48)
* Modified key derivation and address generation functions (`Mnemonic.to0xPrivateKey`, `Mnemonic.to0xAddress`, `deriveNodes`, `WalletNode.fromMnemonic`) to accept and use the mnemonic password for seed derivation. [[1]](diffhunk://#diff-8007ca257179c4eb310675a6c7d2f3d3286a659081cd24be584847be766212d3L37-R55) [[2]](diffhunk://#diff-77eed10e3628d2e79beac1be2fb50f8924878f73fe9ce94a87b7ea5b1abc12d2L32-R42) [[3]](diffhunk://#diff-77eed10e3628d2e79beac1be2fb50f8924878f73fe9ce94a87b7ea5b1abc12d2L60-R65)

**Wallet signing and transaction flow:**

* Updated signing and transaction generation methods to require the mnemonic password for wallets that use one, and to fail if the wrong password is supplied. This includes changes to `RailgunWallet.getSpendingKeyPair`, `RailgunWallet.sign`, `Transaction`, and `TransactionBatch`. [[1]](diffhunk://#diff-021b0fef3d8b0734b70d025521d0eaf86c6dfd5b644d4ed8bd2b8ae143f20a7bL20-R33) [[2]](diffhunk://#diff-021b0fef3d8b0734b70d025521d0eaf86c6dfd5b644d4ed8bd2b8ae143f20a7bL36-R110) [[3]](diffhunk://#diff-97f443ca5cd94ec4cef05dc001b73a6ddcee7b3f448e51c128f8c02840acf262R138-R142) [[4]](diffhunk://#diff-4774b2955343c687b9fa62e311114a02912d2a07d751e27fa53d1f45e42bed76R374) [[5]](diffhunk://#diff-4774b2955343c687b9fa62e311114a02912d2a07d751e27fa53d1f45e42bed76R450) [[6]](diffhunk://#diff-4774b2955343c687b9fa62e311114a02912d2a07d751e27fa53d1f45e42bed76R482) [[7]](diffhunk://#diff-4774b2955343c687b9fa62e311114a02912d2a07d751e27fa53d1f45e42bed76R596) [[8]](diffhunk://#diff-4774b2955343c687b9fa62e311114a02912d2a07d751e27fa53d1f45e42bed76R626)

**Testing and documentation:**

* Added comprehensive tests to verify that mnemonic-password wallets are distinct from no-password wallets, require the correct password on load and spend, and fail loudly on incorrect or missing passwords. [[1]](diffhunk://#diff-859e466034a002f91405b7bbcf4c1728f026413102bc97df671225c346f77950R87-R169) [[2]](diffhunk://#diff-e62d467ab16fcbf1cb5d98106db28248d2b6045a48f314282e5141fe6a2d5b2cR853-R891)
* Updated the `README.md` to document the new mnemonic password support, including usage notes and API changes.